### PR TITLE
Fix unnecessary parentheses in def of SyncReadData

### DIFF
--- a/src/tendisplus/replication/repl_util.h
+++ b/src/tendisplus/replication/repl_util.h
@@ -16,7 +16,7 @@ namespace tendisplus {
 #define CLUSTER_SLOTS 16384
 
 #define SyncReadData(data, len, timeout)                              \
-  Expected<std::string>(data) =                                       \
+  Expected<std::string> data =                                       \
     _client->read((len), std::chrono::seconds((timeout)));            \
   if (!data.ok()) {                                                   \
     LOG(ERROR) << "SyncReadData failed:" << data.status().toString(); \


### PR DESCRIPTION
In gcc 8.x, warning as error case, [-Werror=parentheses] will cause compilation error, because in the macro def, there is an unnecessary parentheses

## Description
Just remove unnecessary parentheses in the macro def of 
#define SyncReadData(data, len, timeout)   

## Motivation and Context
Without this change, compilation with gcc8.x will fail.
`/work/Tendis/src/tendisplus/cluster/migrate_sender.cpp: 在成员函数‘tendisplus::Expected<long unsigned int> tendisplus::ChunkMigrateSender::sendRange(tendisplus::Transaction*, uint32_t, uint32_t, uint32_t*)’中:
/work/Tendis/src/tendisplus/replication/repl_util.h:19:24: 错误：unnecessary parentheses in declaration of ‘exptData’ [-Werror=parentheses]
   Expected<std::string>(data) =                                       \
                        ^
/work/Tendis/src/tendisplus/cluster/migrate_sender.cpp:252:7: 附注：in expansion of macro ‘SyncReadData’
       SyncReadData(exptData, _OKSTR.length(), timeoutSec);
       ^~~~~~~~~~~~
`
## How Has This Been Tested?
Just fix the compilation.

## Types of Changes
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] Code follows the code style of this project.
- [ ] Change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.