### PR TITLE
suport sort command clusterSingle mode

### DIFF
--- a/src/tendisplus/commands/sort.cpp
+++ b/src/tendisplus/commands/sort.cpp
@@ -169,9 +169,12 @@ class SortCommand : public Command {
     const auto& args = sess->getArgs();
     const auto& key = args[1];
     bool desc(false), alpha(false), store(false), nosort(false), sortby(false),
-      exist(true);
+      exist(true), clusterSingle(false);
     int32_t offset(-1), count(-1);
     size_t storeKeyIndex;
+
+    const auto& cfg = sess->getServerEntry()->getParams();
+    clusterSingle = cfg->clusterSingleNode;
 
     /* 1.precheck */
     std::vector<SortOp> ops(1);
@@ -209,13 +212,13 @@ class SortCommand : public Command {
         } else {
           /* If BY is specified with a real patter, we can't accept
            * it in cluster mode. */
-          if (sess->getServerEntry()->isClusterEnabled()) {
+          if (sess->getServerEntry()->isClusterEnabled() && !clusterSingle) {
             return {ErrorCodes::ERR_PARSEOPT,
                     "BY option of SORT denied in Cluster mode."};
           }
         }
       } else if (!::strcasecmp(args[i].c_str(), "get") && leftargs >= 1) {
-        if (sess->getServerEntry()->isClusterEnabled()) {
+        if (sess->getServerEntry()->isClusterEnabled() && !clusterSingle) {
           return {ErrorCodes::ERR_PARSEOPT,
                   "GET option of SORT denied in Cluster mode."};
         }


### PR DESCRIPTION
## Description
Open clusterSingleNode configuration,should support sort command.

## Motivation and Context
When I turn on the clusterSingleNode configuration, the corresponding commands should be processed as expected.
For example, the sort command is correctly supported.

## How Has This Been Tested?


## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Code follows the code style of this project.
- [ ] Change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.