### PR TITLE
Save disk read bandwidth for compaction by reading right types of keys

### DIFF
--- a/src/tendisplus/storage/rocks/rocks_kvttlcompactfilter.cpp
+++ b/src/tendisplus/storage/rocks/rocks_kvttlcompactfilter.cpp
@@ -36,6 +36,15 @@ class KVTtlCompactionFilter : public CompactionFilter {
     return "KVTTLCompactionFilter";
   }
 
+  virtual rocksdb::CompactionFilter::Decision FilterBlobByKey(int /*level*/, const rocksdb::Slice& key,
+                                   std::string* /*new_value*/,
+                                   std::string* /*skip_until*/) const {
+    if (RecordKey::decodeType(key.data(), key.size()) == RecordType::RT_DATA_META) {
+      return rocksdb::CompactionFilter::Decision::kUndetermined;
+    }
+    return rocksdb::CompactionFilter::Decision::kKeep;
+  }
+
   virtual bool Filter(int /*level*/,
                       const rocksdb::Slice& key,
                       const rocksdb::Slice& existing_value,


### PR DESCRIPTION
## Description
When blobdb enabled, avoid consuming read disk bandwidth by just checking keys of RT_DATA_META type.
It solves #234 

## Motivation and Context
The read bandwidth is too high when enabling the RocksDB's blobdb feature.
And it is found out that it is partly because reading the blob values of large hash field value(> min_blob_size).
And TTL for keys is only saved in RT_DATA_META type keys.
This PR only reads blob values of  RT_DATA_META type, saving read IO.

## How Has This Been Tested?
Tested in lab, the bandwidth is significantly lower when using hash data types with large hash values.

## Types of Changes
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] Code follows the code style of this project.
- [ ] Change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.