### PR TITLE
1."info commandstats" command return value contains waiting time, 2. add echokey command for test.

### DIFF
--- a/.github/workflows/Tendis-CI.yml
+++ b/.github/workflows/Tendis-CI.yml
@@ -19,6 +19,7 @@ jobs:
           pip3 install cpplint
           export PATH=$PATH:~/.local/bin/
           cpplint --version
+          clang-format --version
       - name: Lint
         run: |
           export PATH=$PATH:~/.local/bin/

--- a/src/tendisplus/commands/command.cpp
+++ b/src/tendisplus/commands/command.cpp
@@ -4,11 +4,13 @@
 
 #include "tendisplus/commands/command.h"
 
+#include <iostream>
 #include <limits>
 #include <list>
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -65,9 +67,14 @@ void Command::incrNanos(uint64_t v) {
   _totalNanoSecs.fetch_add(v, std::memory_order_relaxed);
 }
 
+void Command::incrNanosFromRead(uint64_t v) {
+  _totalNanoSecsFromRead.fetch_add(v, std::memory_order_relaxed);
+}
+
 void Command::resetStatInfo() {
   _callTimes = 0;
   _totalNanoSecs = 0;
+  _totalNanoSecsFromRead = 0;
 }
 
 uint64_t Command::getCallTimes() const {
@@ -76,6 +83,10 @@ uint64_t Command::getCallTimes() const {
 
 uint64_t Command::getNanos() const {
   return _totalNanoSecs.load(std::memory_order_relaxed);
+}
+
+uint64_t Command::getNanosFromRead() const {
+  return _totalNanoSecsFromRead.load(std::memory_order_relaxed);
 }
 
 bool Command::isReadOnly() const {
@@ -287,6 +298,7 @@ Expected<std::string> Command::runSessionCmd(Session* sess) {
     auto duration = end - startTs;
     auto executeTime = end - now;
     it->second->incrNanos(executeTime);
+    it->second->incrNanosFromRead(duration);
     sess->getServerEntry()->slowlogPushEntryIfNeeded(
       now / 1000, duration / 1000, executeTime / 1000, sess);
   });

--- a/src/tendisplus/commands/command.h
+++ b/src/tendisplus/commands/command.h
@@ -46,8 +46,10 @@ class Command {
   const std::string& getName() const;
   void incrCallTimes();
   void incrNanos(uint64_t);
+  void incrNanosFromRead(uint64_t);
   uint64_t getCallTimes() const;
   uint64_t getNanos() const;
+  uint64_t getNanosFromRead() const;
   void resetStatInfo();
   bool isReadOnly() const;
   bool isMultiKey() const;
@@ -179,6 +181,7 @@ class Command {
 
   std::atomic<uint64_t> _callTimes;
   std::atomic<uint64_t> _totalNanoSecs;
+  std::atomic<uint64_t> _totalNanoSecsFromRead;
 };
 
 std::unordered_map<std::string, Command*>& commandMap();

--- a/src/tendisplus/commands/command_test.cpp
+++ b/src/tendisplus/commands/command_test.cpp
@@ -3,10 +3,15 @@
 // project for additional information.
 
 #include <algorithm>
+#include <cstdio>
 #include <fstream>
+#include <iostream>
 #include <limits>
+#include <list>
+#include <map>
 #include <memory>
 #include <random>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -53,7 +58,7 @@ void testSetRetry(std::shared_ptr<ServerEntry> svr) {
 
   sess.setArgs({"set", "a", "1"});
   auto expect = Command::runSessionCmd(&sess);
-  EXPECT_EQ(cnt, uint32_t(6));
+  EXPECT_EQ(cnt, static_cast<uint32_t>(6));
   EXPECT_EQ(expect.status().code(), ErrorCodes::ERR_COMMIT_RETRY);
 }
 
@@ -1975,6 +1980,7 @@ TEST(Command, info) {
     {"info", "binloginfo"},
     {"info", "cpu"},
     {"info", "commandstats"},
+    {"info", "commandstats", "showExe"},
     {"info", "cluster"},
     {"info", "keyspace"},
     {"info", "backup"},
@@ -2015,7 +2021,7 @@ TEST(Command, info) {
   };
 
   std::vector<std::vector<std::string>> wrongArr = {
-    {"info", "all", "1"},
+    {"info", "all", "1", "1"},
     {"rocksproperty", "rocks.base_level", "100"},
     {"rocksproperty", "all1", "0"},
     {"rocksproperty", "rocks.base_level1"},

--- a/src/tendisplus/commands/debug.cpp
+++ b/src/tendisplus/commands/debug.cpp
@@ -454,6 +454,31 @@ class EchoCommand : public Command {
   }
 } echoCmd;
 
+class EchoKeyCommand : public Command {
+ public:
+  EchoKeyCommand() : Command("echokey", "F") {}
+
+  ssize_t arity() const {
+    return 2;
+  }
+
+  int32_t firstkey() const {
+    return 0;
+  }
+
+  int32_t lastkey() const {
+    return 0;
+  }
+
+  int32_t keystep() const {
+    return 0;
+  }
+
+  Expected<std::string> run(Session* sess) final {
+    return Command::fmtBulk(sess->getArgs()[1]);
+  }
+} echokeyCmd;
+
 class TimeCommand : public Command {
  public:
   TimeCommand() : Command("time", "RF") {}
@@ -2036,7 +2061,7 @@ class InfoCommand : public Command {
     }
     section = toLower(section);
 
-    if (sess->getArgs().size() > 2) {
+    if (sess->getArgs().size() > 3) {
       return {ErrorCodes::ERR_PARSEOPT, "invalid args size"};
     }
 
@@ -2342,13 +2367,23 @@ class InfoCommand : public Command {
       ss << "# CommandStats\r\n";
       for (const auto& kv : commandMap()) {
         auto calls = kv.second->getCallTimes();
-        auto usec = kv.second->getNanos() / 1000;
+        // include wait time in the NetSession::_queryBuf
+        auto usecFromRead = kv.second->getNanosFromRead() / 1000;
+        // only exe time
+        auto usecExe = kv.second->getNanos() / 1000;
         if (calls == 0)
           continue;
 
-        ss << "cmdstat_" << kv.first << ":calls=" << calls << ",usec=" << usec
-           << ",usec_per_call="
-           << ((calls == 0) ? 0 : (static_cast<float>(usec) / calls)) << "\r\n";
+        ss << "cmdstat_" << kv.first << ":calls=" << calls
+           << ",usec=" << usecFromRead << ",usec_per_call="
+           << ((calls == 0) ? 0 : (static_cast<float>(usecFromRead) / calls));
+
+        auto& args = sess->getArgs();
+        if (args.size() == 3 && toLower("showExe") == toLower(args[2])) {
+          ss << ",usec_exe=" << usecExe << ",usec_exe_per_call="
+             << ((calls == 0) ? 0 : (static_cast<float>(usecExe) / calls));
+        }
+        ss << "\r\n";
       }
       uint32_t unseenCmdNum = 0;
       uint64_t unseenCmdCalls = 0;


### PR DESCRIPTION
1. The "usec_per_call" field returned by the "info commandstats" command contains the time spent waiting inside the NetSession::_queryBuf. #306 

使用示例：
```
> info commandstats
# CommandStats
cmdstat_get:calls=210161282,usec=1185067280912,usec_per_call=5638.85

> info commandstats showexe
# CommandStats
cmdstat_get:calls=210161282,usec=1185067280912,usec_per_call=5638.85,usec_exe=6101398631,usec_exe_per_call=29.032
```

2. Add echokey command for test.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Code follows the code style of this project.
- [ ] Change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.