### PR TITLE
2.7.tx

### DIFF
--- a/.github/workflows/Tendis-CI.yml
+++ b/.github/workflows/Tendis-CI.yml
@@ -19,6 +19,7 @@ jobs:
           pip3 install cpplint
           export PATH=$PATH:~/.local/bin/
           cpplint --version
+          clang-format --version
       - name: Lint
         run: |
           export PATH=$PATH:~/.local/bin/

--- a/src/tendisplus/cluster/cluster_manager.cpp
+++ b/src/tendisplus/cluster/cluster_manager.cpp
@@ -7,9 +7,15 @@
 #include <bitset>
 #include <cmath>
 #include <cstring>
+#include <list>
+#include <memory>
 #include <set>
 #include <sstream>
+#include <string>
 #include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "tendisplus/commands/command.h"
 #include "tendisplus/storage/varint.h"
@@ -782,8 +788,7 @@ void ClusterNode::setSession(std::shared_ptr<ClusterSession> sess) {
   INVARIANT_D(!_nodeSession);
   _nodeSession = sess;
   if (sess) {
-    LOG(INFO) << "ClusterNode setSession,"
-              << " node name:" << _nodeName
+    LOG(INFO) << "ClusterNode setSession," << " node name:" << _nodeName
               << " node addr:" << sess->getRemoteRepr()
               << " session id:" << sess->id();
   } else {
@@ -1101,7 +1106,7 @@ void ClusterState::clusterHandleConfigEpochCollision(CNodePtr sender) {
             "WARNING: configEpoch collision with node %.40s."
             " configEpoch set to %lu",
             sender->getNodeName().c_str(),
-            (uint64_t)_currentEpoch);
+            static_cast<uint64_t>(_currentEpoch));
 }
 
 uint64_t ClusterState::getCurrentEpoch() const {
@@ -1277,10 +1282,8 @@ Expected<CNodePtr> ClusterState::clusterHandleRedirect(uint32_t slot,
 
   if (node != _myself) {
     std::stringstream ss;
-    ss << "-"
-       << "MOVED"
-       << " " << slot << " " << node->getNodeIp() << ":" << node->getPort()
-       << "\r\n";
+    ss << "-" << "MOVED" << " " << slot << " " << node->getNodeIp() << ":"
+       << node->getPort() << "\r\n";
     return {ErrorCodes::ERR_MOVED, ss.str()};
   }
   return node;
@@ -1489,8 +1492,7 @@ Expected<std::string> ClusterState::getNodeInfo(CNodePtr n) {
     if (emigrStr.ok()) {
       stream << "migrateSlots:" << emigrStr.value() << "\n";
     } else {
-      stream << "migrateSlots:null"
-             << "\n";
+      stream << "migrateSlots:null" << "\n";
     }
   }
   stream << "flag:" << flags << "\n"
@@ -1891,9 +1893,8 @@ Status ClusterState::clusterSetMaster(CNodePtr node,
   }
 
   LOG(INFO) << "replication set node:" << node->getNodeName()
-            << " as my master,"
-            << "ip:" << node->getNodeIp() << " port:" << node->getPort()
-            << ",ignoreRepl:" << ignoreRepl;
+            << " as my master," << "ip:" << node->getNodeIp()
+            << " port:" << node->getPort() << ",ignoreRepl:" << ignoreRepl;
 
   resetManualFailover();
 
@@ -3510,8 +3511,8 @@ std::string ClusterMsg::msgEncode() {  // NOLINT
   setTotlen(static_cast<uint32_t>(head.size() + data.size() + sigLen));
 
   CopyUint(&key, _totlen);
-  CopyUint(&key, (uint16_t)_type);
-  CopyUint(&key, (uint32_t)_mflags);
+  CopyUint(&key, static_cast<uint16_t>(_type));
+  CopyUint(&key, static_cast<uint32_t>(_mflags));
 
   key.insert(key.end(), head.begin(), head.end());
 
@@ -4379,9 +4380,8 @@ Status ClusterManager::startup() {
     auto name = _clusterState->getMyselfNode()->getNodeName();
     auto state = _clusterState->getClusterState();
     std::string clusterState = (unsigned(state) > 0) ? "OK" : "FAIL";
-    LOG(INFO) << "cluster init success:"
-              << " myself node name " << name << " cluster state is "
-              << clusterState;
+    LOG(INFO) << "cluster init success:" << " myself node name " << name
+              << " cluster state is " << clusterState;
   }
 
   std::shared_ptr<ServerParams> params = _svr->getParams();
@@ -4813,7 +4813,7 @@ void ClusterState::cronCheckFailState() {
             "*** NODE %.40s possibly failing, myself:%s, _pingSent delay:%u",
             node->getNodeName().c_str(),
             _myself->getNodeName().c_str(),
-            (uint32_t)delay);
+            static_cast<uint32_t>(delay));
           node->setNodePfail();
           updateState = true;
         }
@@ -5350,6 +5350,7 @@ void ClusterSession::drainReqNet() {
   _sock.async_read_some(
     asio::buffer(_queryBuf.data() + _queryBufPos, readlen),
     [this, self, curr](const std::error_code& ec, size_t actualLen) {
+      _reqMatrix->readed += 1;
       drainReqCallback(ec, actualLen);
     });
 }
@@ -5386,6 +5387,8 @@ void ClusterSession::drainReqCallback(const std::error_code& ec,
 
 void ClusterSession::processReq() {
   _ctx->setProcessPacketStart(nsSinceEpoch());
+  _reqMatrix->waitCost +=
+    _ctx->getProcessPacketStart() - _ctx->getReadPacketTs();
   auto status = clusterProcessPacket();
   _reqMatrix->processed += 1;
   _reqMatrix->processCost += nsSinceEpoch() - _ctx->getProcessPacketStart();
@@ -5555,7 +5558,7 @@ Status ClusterState::clusterProcessPacket(std::shared_ptr<ClusterSession> sess,
   auto hdr = msg.getHeader();
   auto type = msg.getType();
 
-  _statsMessagesReceived[(uint16_t)type]++;
+  _statsMessagesReceived[static_cast<uint16_t>(type)]++;
 
   uint16_t flags = hdr->_flags;
   uint64_t senderCurrentEpoch = 0, senderConfigEpoch = 0;
@@ -5722,7 +5725,7 @@ Status ClusterState::clusterProcessPacket(std::shared_ptr<ClusterSession> sess,
                   "About node %.40s added %d ms ago, having flags %d,"
                   " addr %s:%lu",
                   sessNode->getNodeName().c_str(),
-                  (uint32_t)(msSinceEpoch() - sessNode->getCtime()),
+                  static_cast<uint32_t>(msSinceEpoch() - sessNode->getCtime()),
                   sessNode->getFlags(),
                   sessNode->getNodeIp().c_str(),
                   sessNode->getPort());
@@ -6075,7 +6078,7 @@ Status ClusterSession::clusterProcessPacket() {
   serverLog(LL_DEBUG,
             "--- Processing packet of type %s, %u bytes",
             ClusterMsg::clusterGetMessageTypeString(type).c_str(),
-            (uint32_t)totlen);
+            static_cast<uint32_t>(totlen));
 
   if (totlen < 16 || totlen > _pkgSize) {
     return {ErrorCodes::ERR_DECODE, "invalid message len"};
@@ -6103,7 +6106,7 @@ Status ClusterState::clusterSendUpdate(std::shared_ptr<ClusterSession> sess,
                                        uint64_t offset) {
   ClusterMsg msg(
     ClusterMsg::Type::UPDATE, shared_from_this(), _server, offset, node);
-  _statsMessagesSent[uint16_t(ClusterMsg::Type::UPDATE)]++;
+  _statsMessagesSent[static_cast<uint16_t>(ClusterMsg::Type::UPDATE)]++;
   return sess->clusterSendMessage(msg);
 }
 
@@ -6257,7 +6260,7 @@ Status ClusterState::clusterSendPingNoLock(std::shared_ptr<ClusterSession> sess,
   }
   INVARIANT_D(gossipcount == msg.getEntryCount());
 
-  _statsMessagesSent[uint16_t(type)]++;
+  _statsMessagesSent[static_cast<uint16_t>(type)]++;
   return sess->clusterSendMessage(msg);
 }
 

--- a/src/tendisplus/commands/command.cpp
+++ b/src/tendisplus/commands/command.cpp
@@ -4,11 +4,13 @@
 
 #include "tendisplus/commands/command.h"
 
+#include <iostream>
 #include <limits>
 #include <list>
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -65,9 +67,14 @@ void Command::incrNanos(uint64_t v) {
   _totalNanoSecs.fetch_add(v, std::memory_order_relaxed);
 }
 
+void Command::incrNanosFromRead(uint64_t v) {
+  _totalNanoSecsFromRead.fetch_add(v, std::memory_order_relaxed);
+}
+
 void Command::resetStatInfo() {
   _callTimes = 0;
   _totalNanoSecs = 0;
+  _totalNanoSecsFromRead = 0;
 }
 
 uint64_t Command::getCallTimes() const {
@@ -76,6 +83,10 @@ uint64_t Command::getCallTimes() const {
 
 uint64_t Command::getNanos() const {
   return _totalNanoSecs.load(std::memory_order_relaxed);
+}
+
+uint64_t Command::getNanosFromRead() const {
+  return _totalNanoSecsFromRead.load(std::memory_order_relaxed);
 }
 
 bool Command::isReadOnly() const {
@@ -287,6 +298,7 @@ Expected<std::string> Command::runSessionCmd(Session* sess) {
     auto duration = end - startTs;
     auto executeTime = end - now;
     it->second->incrNanos(executeTime);
+    it->second->incrNanosFromRead(duration);
     sess->getServerEntry()->slowlogPushEntryIfNeeded(
       now / 1000, duration / 1000, executeTime / 1000, sess);
   });

--- a/src/tendisplus/commands/command.h
+++ b/src/tendisplus/commands/command.h
@@ -46,8 +46,10 @@ class Command {
   const std::string& getName() const;
   void incrCallTimes();
   void incrNanos(uint64_t);
+  void incrNanosFromRead(uint64_t);
   uint64_t getCallTimes() const;
   uint64_t getNanos() const;
+  uint64_t getNanosFromRead() const;
   void resetStatInfo();
   bool isReadOnly() const;
   bool isMultiKey() const;
@@ -179,6 +181,7 @@ class Command {
 
   std::atomic<uint64_t> _callTimes;
   std::atomic<uint64_t> _totalNanoSecs;
+  std::atomic<uint64_t> _totalNanoSecsFromRead;
 };
 
 std::unordered_map<std::string, Command*>& commandMap();

--- a/src/tendisplus/commands/command_test.cpp
+++ b/src/tendisplus/commands/command_test.cpp
@@ -3,10 +3,15 @@
 // project for additional information.
 
 #include <algorithm>
+#include <cstdio>
 #include <fstream>
+#include <iostream>
 #include <limits>
+#include <list>
+#include <map>
 #include <memory>
 #include <random>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -53,7 +58,7 @@ void testSetRetry(std::shared_ptr<ServerEntry> svr) {
 
   sess.setArgs({"set", "a", "1"});
   auto expect = Command::runSessionCmd(&sess);
-  EXPECT_EQ(cnt, uint32_t(6));
+  EXPECT_EQ(cnt, static_cast<uint32_t>(6));
   EXPECT_EQ(expect.status().code(), ErrorCodes::ERR_COMMIT_RETRY);
 }
 
@@ -1975,6 +1980,7 @@ TEST(Command, info) {
     {"info", "binloginfo"},
     {"info", "cpu"},
     {"info", "commandstats"},
+    {"info", "commandstats", "showExe"},
     {"info", "cluster"},
     {"info", "keyspace"},
     {"info", "backup"},
@@ -2015,7 +2021,7 @@ TEST(Command, info) {
   };
 
   std::vector<std::vector<std::string>> wrongArr = {
-    {"info", "all", "1"},
+    {"info", "all", "1", "1"},
     {"rocksproperty", "rocks.base_level", "100"},
     {"rocksproperty", "all1", "0"},
     {"rocksproperty", "rocks.base_level1"},

--- a/src/tendisplus/commands/debug.cpp
+++ b/src/tendisplus/commands/debug.cpp
@@ -452,6 +452,31 @@ class EchoCommand : public Command {
   }
 } echoCmd;
 
+class EchoKeyCommand : public Command {
+ public:
+  EchoKeyCommand() : Command("echokey", "F") {}
+
+  ssize_t arity() const {
+    return 2;
+  }
+
+  int32_t firstkey() const {
+    return 0;
+  }
+
+  int32_t lastkey() const {
+    return 0;
+  }
+
+  int32_t keystep() const {
+    return 0;
+  }
+
+  Expected<std::string> run(Session* sess) final {
+    return Command::fmtBulk(sess->getArgs()[1]);
+  }
+} echokeyCmd;
+
 class TimeCommand : public Command {
  public:
   TimeCommand() : Command("time", "RF") {}
@@ -2025,7 +2050,7 @@ class InfoCommand : public Command {
     }
     section = toLower(section);
 
-    if (sess->getArgs().size() > 2) {
+    if (sess->getArgs().size() > 3) {
       return {ErrorCodes::ERR_PARSEOPT, "invalid args size"};
     }
 
@@ -2343,13 +2368,23 @@ class InfoCommand : public Command {
       ss << "# CommandStats\r\n";
       for (const auto& kv : commandMap()) {
         auto calls = kv.second->getCallTimes();
-        auto usec = kv.second->getNanos() / 1000;
+        // include wait time in the NetSession::_queryBuf
+        auto usecFromRead = kv.second->getNanosFromRead() / 1000;
+        // only exe time
+        auto usecExe = kv.second->getNanos() / 1000;
         if (calls == 0)
           continue;
 
-        ss << "cmdstat_" << kv.first << ":calls=" << calls << ",usec=" << usec
-           << ",usec_per_call="
-           << ((calls == 0) ? 0 : (static_cast<float>(usec) / calls)) << "\r\n";
+        ss << "cmdstat_" << kv.first << ":calls=" << calls
+           << ",usec=" << usecFromRead << ",usec_per_call="
+           << ((calls == 0) ? 0 : (static_cast<float>(usecFromRead) / calls));
+
+        auto& args = sess->getArgs();
+        if (args.size() == 3 && toLower("showExe") == toLower(args[2])) {
+          ss << ",usec_exe=" << usecExe << ",usec_exe_per_call="
+             << ((calls == 0) ? 0 : (static_cast<float>(usecExe) / calls));
+        }
+        ss << "\r\n";
       }
       uint32_t unseenCmdNum = 0;
       uint64_t unseenCmdCalls = 0;

--- a/src/tendisplus/network/network.cpp
+++ b/src/tendisplus/network/network.cpp
@@ -57,20 +57,25 @@ const int BUFFER_LONG_SIZE = 10 * 1024 * 1024;
 
 std::string RequestMatrix::toString() const {
   std::stringstream ss;
-  ss << "\nprocessed\t" << processed << "\nprocessCost\t" << processCost << "ns"
-     << "\nsendPacketCost\t" << sendPacketCost << "ns";
+  ss << " readed:" << readed << " processed:" << processed
+     << " waitCost:" << waitCost << "ns" << " processCost:" << processCost
+     << "ns" << " sendPacketCost:" << sendPacketCost << "ns";
   return ss.str();
 }
 
 void RequestMatrix::reset() {
+  readed = 0;
   processed = 0;
+  waitCost = 0;
   processCost = 0;
   sendPacketCost = 0;
 }
 
 RequestMatrix RequestMatrix::operator-(const RequestMatrix& right) {
   RequestMatrix result;
+  result.readed = readed - right.readed;
   result.processed = processed - right.processed;
+  result.waitCost = waitCost - right.waitCost;
   result.processCost = processCost - right.processCost;
   result.sendPacketCost = sendPacketCost - right.sendPacketCost;
   return result;
@@ -78,9 +83,9 @@ RequestMatrix RequestMatrix::operator-(const RequestMatrix& right) {
 
 std::string NetworkMatrix::toString() const {
   std::stringstream ss;
-  ss << "\nstickyPackets\t" << stickyPackets << "\nconnCreated\t" << connCreated
-     << "\nconnReleased\t" << connReleased << "\ninvalidPackets\t"
-     << invalidPackets;
+  ss << " stickyPackets:" << stickyPackets << " connCreated:" << connCreated
+     << " connReleased:" << connReleased
+     << " invalidPackets:" << invalidPackets;
   return ss.str();
 }
 
@@ -984,6 +989,7 @@ void NetSession::drainReqNet() {
     asio::buffer(_queryBuf.data() + _queryBufPos, wantLen),
     [this, self](const std::error_code& ec, size_t actualLen) {
       _ctx->setReadPacketTs(nsSinceEpoch());
+      _reqMatrix->readed += 1;
       drainReqCallback(ec, actualLen);
     });
 }
@@ -992,6 +998,8 @@ void NetSession::processReq() {
   bool continueSched = true;
   if (_args.size()) {
     _ctx->setProcessPacketStart(nsSinceEpoch());
+    _reqMatrix->waitCost +=
+      _ctx->getProcessPacketStart() - _ctx->getReadPacketTs();
     continueSched = _server->processRequest(reinterpret_cast<Session*>(this));
     _reqMatrix->processed += 1;
     _reqMatrix->processCost += nsSinceEpoch() - _ctx->getProcessPacketStart();

--- a/src/tendisplus/network/network.h
+++ b/src/tendisplus/network/network.h
@@ -52,7 +52,9 @@ class NetworkMatrix {
 
 class RequestMatrix {
  public:
+  Atom<uint64_t> readed{0};          // number of async_read
   Atom<uint64_t> processed{0};       // number of commands
+  Atom<uint64_t> waitCost{0};        // waiting time in NetSession::_queryBuf
   Atom<uint64_t> processCost{0};     // time cost for commands (ns)
   Atom<uint64_t> sendPacketCost{0};  //
   RequestMatrix operator-(const RequestMatrix& right);

--- a/src/tendisplus/network/worker_pool.cpp
+++ b/src/tendisplus/network/worker_pool.cpp
@@ -6,8 +6,10 @@
 
 #include <cstdlib>
 #include <functional>
+#include <memory>
 #include <string>
 #include <thread>
+#include <utility>
 
 #include "tendisplus/utils/invariant.h"
 #include "tendisplus/utils/scopeguard.h"
@@ -16,17 +18,17 @@ namespace tendisplus {
 
 std::string PoolMatrix::toString() const {
   std::stringstream ss;
-  ss << "\ninQueue\t" << inQueue << "\nexecuting\t" << executing
-     << "\nexecuted\t" << executed << "\nqueueTime\t" << queueTime << "ns"
-     << "\nexecuteTime\t" << executeTime << "ns";
+  ss << " inQueue:" << inQueue << " executing:" << executing
+     << " executed:" << executed << " queueTime:" << queueTime << "ns"
+     << " executeTime:" << executeTime << "ns";
   return ss.str();
 }
 
 std::string PoolMatrix::getInfoString() const {
   std::stringstream ss;
   ss << "inQueue " << inQueue << ",executing " << executing << ",executed "
-     << executed << ",queueTime " << queueTime << "ns"
-     << ",executeTime " << executeTime << "ns";
+     << executed << ",queueTime " << queueTime << "ns" << ",executeTime "
+     << executeTime << "ns";
   return ss.str();
 }
 

--- a/src/tendisplus/server/server_entry.cpp
+++ b/src/tendisplus/server/server_entry.cpp
@@ -1327,38 +1327,55 @@ void ServerEntry::getStatInfo(std::stringstream& ss) const {
      << "\r\n";
   ss << "total_connections_released:" << _netMatrix->connReleased.get()
      << "\r\n";
+  auto readed = _reqMatrix->readed.get();
   auto executed = _reqMatrix->processed.get();
+  ss << "total_package_readed:" << readed << "\r\n";
   ss << "total_commands_processed:" << executed << "\r\n";
   ss << "instantaneous_ops_per_sec:"
      << _serverStat.getInstantaneousMetric(STATS_METRIC_COMMAND) << "\r\n";
 
-  auto allCost = _poolMatrix->executeTime.get() + _poolMatrix->queueTime.get() +
+  // auto allCost = _poolMatrix->executeTime.get()
+  //   + _poolMatrix->queueTime.get()
+  //   + _reqMatrix->sendPacketCost.get();
+  auto allCost = _reqMatrix->waitCost.get() + _reqMatrix->processCost.get() +
     _reqMatrix->sendPacketCost.get();
   ss << "total_commands_cost(ns):" << allCost << "\r\n";
-  ss << "total_commands_workpool_queue_cost(ns):"
-     << _poolMatrix->queueTime.get() << "\r\n";
-  ss << "total_commands_workpool_execute_cost(ns):"
-     << _poolMatrix->executeTime.get() << "\r\n";
-  ss << "total_commands_send_packet_cost(ns):"
-     << _reqMatrix->sendPacketCost.get() << "\r\n";
+  ss << "total_commands_wait_in_read_buffer_cost(ns):"
+     << _reqMatrix->waitCost.get() << "\r\n";
   ss << "total_commands_execute_cost(ns):" << _reqMatrix->processCost.get()
      << "\r\n";
+  ss << "total_commands_send_packet_cost(ns):"
+     << _reqMatrix->sendPacketCost.get() << "\r\n";
+  // The following two indicators can only count the time-costing of the
+  //   task in workpool, but cannot count the time-costing of the request.
+  ss << "total_task_workpool_queue_cost(ns):" << _poolMatrix->queueTime.get()
+     << "\r\n";
+  ss << "total_task_workpool_execute_cost(ns):"
+     << _poolMatrix->executeTime.get() << "\r\n";
 
   if (executed == 0)
     executed = 1;
   ss << "avg_commands_cost(ns):" << allCost / executed << "\r\n";
-  ss << "avg_commands_workpool_queue_cost(ns):"
-     << _poolMatrix->queueTime.get() / executed << "\r\n";
-  ss << "avg_commands_workpool_execute_cost(ns):"
-     << _poolMatrix->executeTime.get() / executed << "\r\n";
-  ss << "avg_commands_send_packet_cost(ns):"
-     << _reqMatrix->sendPacketCost.get() / executed << "\r\n";
+  ss << "avg_commands_wait_in_read_buffer_cost(ns):"
+     << _reqMatrix->waitCost.get() / executed << "\r\n";
   ss << "avg_commands_execute_cost(ns):"
      << _reqMatrix->processCost.get() / executed << "\r\n";
+  ss << "avg_commands_send_packet_cost(ns):"
+     << _reqMatrix->sendPacketCost.get() / executed << "\r\n";
+  // The following two indicators can only count the time-costing of the
+  //   task in workpool, but cannot count the time-costing of the request.
+  //   This is because a single request may be queued multiple times in
+  //   the queue,and a task that is queued once may process multiple requests.
+  auto taskExecuted = _poolMatrix->executed.get();
+  if (taskExecuted != 0) {
+    ss << "avg_task_workpool_queue_cost(ns):"
+       << _poolMatrix->queueTime.get() / taskExecuted << "\r\n";
+    ss << "avg_task_workpool_execute_cost(ns):"
+       << _poolMatrix->executeTime.get() / taskExecuted << "\r\n";
+  }
 
-  ss << "commands_in_queue:" << _poolMatrix->inQueue.get() << "\r\n";
-  ss << "commands_executed_in_workpool:" << _poolMatrix->executed.get()
-     << "\r\n";
+  ss << "task_in_queue:" << _poolMatrix->inQueue.get() << "\r\n";
+  ss << "task_executed_in_workpool:" << _poolMatrix->executed.get() << "\r\n";
 
   ss << "total_stricky_packets:" << _netMatrix->stickyPackets.get() << "\r\n";
   ss << "total_invalid_packets:" << _netMatrix->invalidPackets.get() << "\r\n";
@@ -1410,8 +1427,12 @@ void ServerEntry::appendJSONStat(
   if (sections.find("request") != sections.end()) {
     w.Key("request");
     w.StartObject();
+    w.Key("readed");
+    w.Uint64(_reqMatrix->readed.get());
     w.Key("processed");
     w.Uint64(_reqMatrix->processed.get());
+    w.Key("wait_cost");
+    w.Uint64(_reqMatrix->waitCost.get());
     w.Key("process_cost");
     w.Uint64(_reqMatrix->processCost.get());
     w.Key("send_packet_cost");
@@ -1782,7 +1803,9 @@ void ServerEntry::serverCron() {
           }
         }
       }
+    }
 
+    run_with_period(1000) {
       // full-time matrix collect
       if (_ftmcEnabled.load(std::memory_order_relaxed)) {
         auto tmpNetMatrix = *_netMatrix - oldNetMatrix;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

1. The "usec_per_call" field returned by the "info commandstats" command contains the time spent waiting inside the NetSession::_queryBuf.  #306
使用示例：

```
> info commandstats
# CommandStats
cmdstat_get:calls=210161282,usec=1185067280912,usec_per_call=5638.85

> info commandstats showexe
# CommandStats
cmdstat_get:calls=210161282,usec=1185067280912,usec_per_call=5638.85,usec_exe=6101398631,usec_exe_per_call=29.032
```
2. Add echokey command for test.
3. 现在的命令延迟统计比较乱，很难反映具体耗时情况，进行了一些修复，并新增了一些统计。以方便分析慢查询相关问题。

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Code follows the code style of this project.
- [ ] Change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.