### PR TITLE
support info latencyMonitor command

### DIFF
--- a/src/tendisplus/commands/command.cpp
+++ b/src/tendisplus/commands/command.cpp
@@ -299,6 +299,7 @@ Expected<std::string> Command::runSessionCmd(Session* sess) {
     auto executeTime = end - now;
     it->second->incrNanos(executeTime);
     it->second->incrNanosFromRead(duration);
+    sess->getServerEntry()->recordLatency(commandName, duration / 1000);
     sess->getServerEntry()->slowlogPushEntryIfNeeded(
       now / 1000, duration / 1000, executeTime / 1000, sess);
   });

--- a/src/tendisplus/commands/command_test.cpp
+++ b/src/tendisplus/commands/command_test.cpp
@@ -3,6 +3,7 @@
 // project for additional information.
 
 #include <algorithm>
+#include <cassert>
 #include <cstdio>
 #include <fstream>
 #include <iostream>
@@ -11,6 +12,7 @@
 #include <map>
 #include <memory>
 #include <random>
+#include <regex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -873,6 +875,70 @@ void testSlowLog(std::shared_ptr<ServerEntry> svr) {
   EXPECT_TRUE(expect.ok());
 }
 
+void testLatencyMonitor(std::shared_ptr<ServerEntry> svr) {
+  asio::io_context ioContext;
+  asio::ip::tcp::socket socket(ioContext), socket1(ioContext);
+  NetSession sess(svr, std::move(socket), 1, false, nullptr, nullptr);
+
+  for (int i = 0; i < 100; i++) {
+    std::string key = "key" + std::to_string(i);
+    std::string value = "value" + std::to_string(i);
+    sess.setArgs({"set", key.c_str(), value.c_str()});
+    auto expect = Command::runSessionCmd(&sess);
+    EXPECT_TRUE(expect.ok());
+  }
+  for (int i = 0; i < 100; i++) {
+    std::string key = "key" + std::to_string(i);
+    sess.setArgs({"get", key.c_str()});
+    auto expect = Command::runSessionCmd(&sess);
+    EXPECT_TRUE(expect.ok());
+  }
+  std::regex pattern(R"(LatencyMonitorName:[^\n]+\n((?:[<=|>|T].*\n)+))");
+  std::smatch matches;
+  bool found = false;
+  for (int i = 0; i < 100; i++) {
+    sess.setArgs({"info"});
+    auto expect = Command::runSessionCmd(&sess);
+    EXPECT_TRUE(expect.ok());
+    found = std::regex_search(expect.value(), matches, pattern);
+    if (found) {
+      assert(matches.size() > 2);
+      std::string res = matches[1];
+      assert(res.size() > 10);
+      auto v = res.substr(res.size() - 10, res.size());
+      EXPECT_EQ(std::stoi(v), 200 + i);
+    }
+    EXPECT_EQ(found, true);
+  }
+  sess.setArgs({"info", "latencymonitor"});
+  auto expect = Command::runSessionCmd(&sess);
+  EXPECT_TRUE(expect.ok());
+  found = std::regex_search(expect.value(), matches, pattern);
+  if (found) {
+    assert(matches.size() > 2);
+    std::string res = matches[1];
+    assert(res.size() > 10);
+    auto v = res.substr(res.size() - 10, res.size());
+    EXPECT_EQ(std::stoi(v), 300);
+  }
+  EXPECT_EQ(found, true);
+  sess.setArgs({"config", "resetStat", "latency"});
+  expect = Command::runSessionCmd(&sess);
+  EXPECT_TRUE(expect.ok());
+  sess.setArgs({"info", "latencymonitor"});
+  expect = Command::runSessionCmd(&sess);
+  EXPECT_TRUE(expect.ok());
+  found = std::regex_search(expect.value(), matches, pattern);
+  if (found) {
+    assert(matches.size() > 2);
+    std::string res = matches[1];
+    assert(res.size() > 10);
+    auto v = res.substr(res.size() - 10, res.size());
+    EXPECT_EQ(std::stoi(v), 1);
+  }
+  EXPECT_EQ(found, true);
+}
+
 void testGlobStylePattern(std::shared_ptr<ServerEntry> svr) {
   asio::io_context ioContext;
   asio::ip::tcp::socket socket(ioContext), socket1(ioContext);
@@ -1235,6 +1301,25 @@ TEST(Command, slowlog) {
   ptr = fgets(line, sizeof(line) - 1, fp);
   EXPECT_STRCASEEQ(line, "[] set ss2 b \n");
   pclose(fp);
+}
+#endif  // !
+
+#ifndef _WIN32
+TEST(Command, latency) {
+  const auto guard = MakeGuard([] { destroyEnv(); });
+
+  {
+    EXPECT_TRUE(setupEnv());
+    auto cfg = makeServerParam();
+    auto server = makeServerEntry(cfg);
+
+    testLatencyMonitor(server);
+
+#ifndef _WIN32
+    server->stop();
+    EXPECT_EQ(server.use_count(), 1);
+#endif
+  }
 }
 #endif  // !
 

--- a/src/tendisplus/commands/debug.cpp
+++ b/src/tendisplus/commands/debug.cpp
@@ -2086,6 +2086,7 @@ class InfoCommand : public Command {
     infoLevelStats(allsections, defsections, section, sess, result);
     infoRocksdbStats(allsections, defsections, section, sess, result);
     infoRocksdbPerfStats(allsections, defsections, section, sess, result);
+    infoLatencyMonitor(allsections, defsections, section, sess, result);
     infoRocksdbBgError(allsections, defsections, section, sess, result);
 
     return Command::fmtBulk(result.str());
@@ -2713,6 +2714,20 @@ class InfoCommand : public Command {
     }
   }
 
+  static void infoLatencyMonitor(bool allsections,
+                                 bool defsections,
+                                 const std::string& section,
+                                 Session* sess,
+                                 std::stringstream& result) {
+    if (allsections || defsections || section == "latencymonitor") {
+      auto server = sess->getServerEntry();
+
+      result << "# LatencyMonitor\r\n";
+      result << server->getLatencyMonitorSet().getLatencyInfo();
+      result << "\r\n";
+    }
+  }
+
   static void infoRocksdbBgError(bool allsections,
                                  bool defsections,
                                  const std::string& section,
@@ -2976,6 +2991,15 @@ class ConfigCommand : public Command {
       LOG(INFO) << ss.str();
       auto svr = sess->getServerEntry();
       svr->resetRocksdbStats(sess);
+    }
+    if (reset_all || configName == "latency") {
+      LOG(INFO) << "reset latency";
+      std::stringstream ss;
+      InfoCommand::infoLatencyMonitor(true, true, "latencymonitor", sess, ss);
+      LOG(INFO) << ss.str();
+
+      auto svr = sess->getServerEntry();
+      svr->resetLatencyStat();
     }
   }
 

--- a/src/tendisplus/server/CMakeLists.txt
+++ b/src/tendisplus/server/CMakeLists.txt
@@ -2,13 +2,16 @@ add_library(session session.cpp)
 target_link_libraries(session status glog commands)
 
 add_library(server server_entry.cpp)
-target_link_libraries(server status network nwp time_util rocks_kvstore segment_mgr catalog repl_manager migrate gc_mgr index_mgr cluster_mgr pessimistic server_params script)
+target_link_libraries(server status network nwp time_util rocks_kvstore segment_mgr catalog repl_manager migrate gc_mgr index_mgr cluster_mgr pessimistic server_params script latency_monitor)
 
 add_library(server_params server_params.cpp)
 target_link_libraries(server_params status glog server gtest_main)
 
 add_library(segment_mgr segment_manager.cpp)
 target_link_libraries(segment_mgr status session lock)
+
+add_library(latency_monitor latency_monitor.cpp)
+target_link_libraries(latency_monitor commands ${SYS_LIBS})
 
 add_library(index_mgr index_manager.cpp)
 target_link_libraries(index_mgr status session lock glog ${SYS_LIBS})

--- a/src/tendisplus/server/latency_monitor.cpp
+++ b/src/tendisplus/server/latency_monitor.cpp
@@ -1,0 +1,81 @@
+// Copyright (C) 2020 THL A29 Limited, a Tencent company.  All rights reserved.
+// Please refer to the license text that comes with this tendis open source
+// project for additional information.
+
+
+#include "tendisplus/server/latency_monitor.h"
+
+#include <stddef.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "tendisplus/commands/command.h"
+#include "tendisplus/utils/string.h"
+
+namespace tendisplus {
+void LatencyMonitor::getInfoString(std::stringstream& ss) {
+  uint64_t tc = mLast.count;
+  for (auto& s : mTimeSpan) {
+    tc += s.count;
+  }
+  if (tc == 0) {
+    return;
+  }
+  uint64_t te = mLast.total;
+  uint64_t t = 0;
+  double p = 0;
+  for (auto& s : mTimeSpan) {
+    if (s.count == 0) {
+      continue;
+    }
+    te += s.total;
+    t += s.count;
+    p = t * 100. / tc;
+    ss << "<= " << std::setw(12) << s.span                          // %12ld
+       << " " << std::setw(20) << s.total                           // %20ld
+       << " " << std::setw(16) << s.count                           // %16ld
+       << " " << std::fixed << std::setprecision(2) << p << "%\n";  // %.2f%%
+  }
+  if (mLast.count > 0) {
+    ss << ">  " << std::setw(12) << mLast.span << " " << std::setw(20)
+       << mLast.total << " " << std::setw(16) << mLast.count << " 100.00%\n";
+  }
+  ss << "T  " << std::setw(12) << te / tc << " " << std::setw(20) << te << " "
+     << std::setw(16) << tc << "\n";
+}
+
+std::string LatencyMonitorSet::getLatencyInfo() {
+  std::stringstream ss;
+  for (auto& monitor : mPool) {
+    ss << "LatencyMonitorName:" << monitor.name() << "\n";
+    monitor.getInfoString(ss);
+    ss << "\n";
+  }
+  return ss.str();
+}
+
+void LatencyMonitorSet::init(const std::vector<LatencyMonitorConf>& confs) {
+  mPool = std::vector<LatencyMonitor>(confs.size());
+  int i = 0;
+  for (auto& c : confs) {
+    mPool[i].init(c);
+    ++i;
+  }
+}
+
+void LatencyMonitorSet::init() {
+  LatencyMonitorConf allCommandsCfg = {"all", {}, {}};
+  allCommandsCfg.cmds = Command::listCommands();
+  auto& spin = allCommandsCfg.timeSpan;
+  uint64_t minSpan = LATENCY_THRESHOLD_MIN, maxSpan = LATENCY_THRESHOLD_MAX;
+  for (uint64_t u = minSpan; u <= maxSpan; u *= 2) {
+    spin.emplace_back(u);
+  }
+  std::vector<LatencyMonitorConf> confs{allCommandsCfg};
+  init(confs);
+}
+
+}  // namespace tendisplus

--- a/src/tendisplus/server/latency_monitor.h
+++ b/src/tendisplus/server/latency_monitor.h
@@ -1,0 +1,139 @@
+// Copyright (C) 2020 THL A29 Limited, a Tencent company.  All rights reserved.
+// Please refer to the license text that comes with this tendis open source
+// project for additional information.
+
+#ifndef SRC_TENDISPLUS_SERVER_LATENCY_MONITOR_H_
+#define SRC_TENDISPLUS_SERVER_LATENCY_MONITOR_H_
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <list>
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#define LATENCY_THRESHOLD_MIN 4'000
+#define LATENCY_THRESHOLD_MAX 2'000'000
+
+namespace tendisplus {
+struct LatencyMonitorConf {
+  std::string name;
+  std::vector<std::string> cmds;
+  std::vector<int> timeSpan;
+};
+
+class LatencyMonitor {
+ public:
+  struct TimeSpan {
+    uint64_t span;
+    std::atomic<uint64_t> total;
+    std::atomic<uint64_t> count;
+
+    bool operator<(const TimeSpan& oth) const {
+      return span < oth.span;
+    }
+    TimeSpan& operator+=(const TimeSpan& s) {
+      total += s.total;
+      count += s.count;
+      return *this;
+    }
+  };
+
+ public:
+  LatencyMonitor() : mLast{0, 0, 0} {}
+  LatencyMonitor& operator+=(const LatencyMonitor& m) {
+    for (size_t i = 0; i < mTimeSpan.size(); ++i) {
+      mTimeSpan[i] += m.mTimeSpan[i];
+    }
+    mLast += m.mLast;
+    return *this;
+  }
+  bool find(const std::string& cmd) const {
+    return mCmds.count(cmd) > 0;
+  }
+  void init(const LatencyMonitorConf& c) {
+    mName = c.name;
+    for (auto& commandName : c.cmds) {
+      mCmds.insert(commandName);
+    }
+    int n = c.timeSpan.size();
+    mTimeSpan = std::vector<TimeSpan>(n);
+    for (int i = 0; i < n; ++i) {
+      mTimeSpan[i].span = c.timeSpan[i];
+      mTimeSpan[i].total = 0;
+      mTimeSpan[i].count = 0;
+    }
+    if (!mTimeSpan.empty()) {
+      mLast.span = mTimeSpan.back().span;
+    }
+  }
+  void reset() {
+    for (auto& s : mTimeSpan) {
+      s.total = 0;
+      s.count = 0;
+    }
+    mLast.total = 0;
+    mLast.count = 0;
+  }
+  const std::string& name() const {
+    return mName;
+  }
+  int add(uint64_t v) {
+    TimeSpan span{v};
+    auto it = std::lower_bound(mTimeSpan.begin(), mTimeSpan.end(), span);
+    if (it == mTimeSpan.end()) {
+      mLast.total += v;
+      ++mLast.count;
+      return mTimeSpan.size();
+    } else {
+      it->total += v;
+      ++it->count;
+      return it - mTimeSpan.begin();
+    }
+  }
+  void add(uint64_t v, int idx) {
+    TimeSpan& s(idx < static_cast<int>(mTimeSpan.size()) ? mTimeSpan[idx]
+                                                         : mLast);
+    s.total += v;
+    ++s.count;
+  }
+  void getInfoString(std::stringstream& ss);
+
+ private:
+  std::string mName;
+  std::unordered_set<std::string> mCmds;
+  std::vector<TimeSpan> mTimeSpan;
+  TimeSpan mLast;
+};
+
+class LatencyMonitorSet {
+ public:
+  LatencyMonitorSet() {}
+  void init(const std::vector<LatencyMonitorConf>& conf);
+  void init();
+  std::string getLatencyInfo();
+  void reset() {
+    for (auto& monitor : mPool) {
+      monitor.reset();
+    }
+  }
+  void addLatencyInfo(const std::string& commandName, uint64_t duration) {
+    for (auto& monitor : mPool) {
+      if (monitor.find(commandName)) {
+        monitor.add(duration);
+      }
+    }
+  }
+  std::vector<LatencyMonitor>& getLatencyMonitors() {
+    return mPool;
+  }
+
+ private:
+  std::vector<LatencyMonitor> mPool;
+};
+}  // namespace tendisplus
+
+#endif  // SRC_TENDISPLUS_SERVER_LATENCY_MONITOR_H_

--- a/src/tendisplus/server/server_entry.cpp
+++ b/src/tendisplus/server/server_entry.cpp
@@ -421,6 +421,10 @@ void ServerEntry::resetServerStat() {
   _serverStat.reset();
 }
 
+void ServerEntry::resetLatencyStat() {
+  _latencyMonitorSet.reset();
+}
+
 void ServerEntry::installPessimisticMgrInLock(
   std::unique_ptr<PessimisticMgr> o) {
   _pessimisticMgr = std::move(o);
@@ -864,6 +868,8 @@ Status ServerEntry::startup(const std::shared_ptr<ServerParams>& cfg) {
     INVARIANT(!pthread_setname_np(pthread_self(), "tx-bgcom-cron"));
     bgCompactCron();
   });
+
+  _latencyMonitorSet.init();
 
   // init slowlog
   _slowlogStat.initSlowlogFile(cfg);

--- a/src/tendisplus/server/server_entry.h
+++ b/src/tendisplus/server/server_entry.h
@@ -27,6 +27,7 @@
 #include "tendisplus/replication/repl_manager.h"
 #include "tendisplus/script/script_manager.h"
 #include "tendisplus/server/index_manager.h"
+#include "tendisplus/server/latency_monitor.h"
 #include "tendisplus/server/segment_manager.h"
 #include "tendisplus/server/server_params.h"
 #include "tendisplus/storage/catalog.h"
@@ -274,12 +275,16 @@ class ServerEntry : public std::enable_shared_from_this<ServerEntry> {
     return (ServerStat&)_serverStat;
   }
   void resetServerStat();
+  void resetLatencyStat();
   void resetRocksdbStats(Session* sess);
   CompactionStat& getCompactionStat() const {
     return (CompactionStat&)_compactionStat;
   }
   SlowlogStat& getSlowlogStat() const {
     return (SlowlogStat&)_slowlogStat;
+  }
+  LatencyMonitorSet& getLatencyMonitorSet() const {
+    return (LatencyMonitorSet&)_latencyMonitorSet;
   }
   void logGeneral(Session* sess);
   void handleShutdownCmd();
@@ -295,6 +300,9 @@ class ServerEntry : public std::enable_shared_from_this<ServerEntry> {
     uint64_t duration, /* including the queue time */
     uint64_t execTime,
     Session* sess);
+  void recordLatency(const std::string commandName, uint64_t duration) {
+    _latencyMonitorSet.addLatencyInfo(commandName, duration);
+  }
   bool setBackupRunning() {
     std::lock_guard<std::mutex> lk(_mutex);
     bool expected = false;
@@ -509,6 +517,7 @@ class ServerEntry : public std::enable_shared_from_this<ServerEntry> {
   ServerStat _serverStat;
   CompactionStat _compactionStat;
   SlowlogStat _slowlogStat;
+  LatencyMonitorSet _latencyMonitorSet;
   uint32_t _lastJeprofDumpMemoryGB;
 };
 }  // namespace tendisplus


### PR DESCRIPTION
## Description
1、添加对info latencyMonitor命令的支持，能够统计所有命令的延时
2、支持对统计延时的清空
3、添加相关的测试用例