### PR TITLE
When a "Lock wait timeout" occurs, dump MGLockMgr information to the log file

### DIFF
--- a/src/tendisplus/lock/lock.cpp
+++ b/src/tendisplus/lock/lock.cpp
@@ -6,6 +6,7 @@
 
 #include <limits>
 #include <memory>
+#include <string>
 
 #include "tendisplus/server/server_entry.h"
 #include "tendisplus/utils/invariant.h"
@@ -79,7 +80,13 @@ StoresLock::StoresLock(mgl::LockMode mode,
                        mgl::MGLockMgr* mgr,
                        uint64_t lockTimeoutMs)
   : ILock(nullptr, new mgl::MGLock(mgr), sess, false) {
-  _lockResult = _mgl->lock(_target, mode, lockTimeoutMs);
+  uint64_t sessId = 0;
+  std::string sessType = "";
+  if (_sess) {
+    sessId = _sess->id();
+    sessType = _sess->getTypeStr();
+  }
+  _lockResult = _mgl->lock(_target, mode, lockTimeoutMs, sessId, sessType);
 }
 
 Expected<std::unique_ptr<StoreLock>> StoreLock::AquireStoreLock(
@@ -93,6 +100,10 @@ Expected<std::unique_ptr<StoreLock>> StoreLock::AquireStoreLock(
   if (lock->getLockResult() == mgl::LockRes::LOCKRES_OK) {
     return lock;
   } else if (lock->getLockResult() == mgl::LockRes::LOCKRES_TIMEOUT) {
+    LOG(WARNING) << "Lock wait timeout, store_" << storeId << " "
+                 << lockModeRepr(mode) << ", threadId:" << getCurThreadId()
+                 << ", Locks:\n"
+                 << mgr->toStringWithLines();
     return {ErrorCodes::ERR_LOCK_TIMEOUT, "Lock wait timeout"};
   } else {
     INVARIANT_D(0);
@@ -114,11 +125,16 @@ StoreLock::StoreLock(uint32_t storeId,
   // NOTE(takenliu): std::to_string() has performance issue in multi thread,
   //     because it will use std::locale(), so use snprintf instead.
   std::string target = "store_" + uitos(storeId);
+  uint64_t sessId = 0;
+  std::string sessType = "";
   if (_sess) {
     _sess->getCtx()->setWaitLock(storeId, 0, "", mode);
+    sessId = _sess->id();
+    sessType = _sess->getTypeStr();
   }
+
   TENDIS_LOCK_LATENCY_RECORD(
-    (_lockResult = _mgl->lock(target, mode, lockTimeoutMs)),
+    (_lockResult = _mgl->lock(target, mode, lockTimeoutMs, sessId, sessType)),
     _sess,
     uitos(_storeId),
     LockLatencyType::LLT_STORE);
@@ -156,11 +172,17 @@ ChunkLock::ChunkLock(uint32_t storeId,
     // NOTE(takenliu): std::to_string() has performance issue in multi thread,
     //     because it will use std::locale(), so use snprintf instead.
     std::string target = "chunk_" + uitos(chunkId);
+
+    uint64_t sessId = 0;
+    std::string sessType = "";
     if (_sess) {
       _sess->getCtx()->setWaitLock(storeId, chunkId, "", mode);
+      sessId = _sess->id();
+      sessType = _sess->getTypeStr();
     }
+
     TENDIS_LOCK_LATENCY_RECORD(
-      (_lockResult = _mgl->lock(target, mode, lockTimeoutMs)),
+      (_lockResult = _mgl->lock(target, mode, lockTimeoutMs, sessId, sessType)),
       _sess,
       uitos(_chunkId),
       LockLatencyType::LLT_CHUNK);
@@ -185,6 +207,10 @@ Expected<std::unique_ptr<ChunkLock>> ChunkLock::AquireChunkLock(
   if (lock->getLockResult() == mgl::LockRes::LOCKRES_OK) {
     return lock;
   } else if (lock->getLockResult() == mgl::LockRes::LOCKRES_TIMEOUT) {
+    LOG(WARNING) << "Lock wait timeout, chunk_" << chunkId << " "
+                 << lockModeRepr(mode) << ", threadId:" << getCurThreadId()
+                 << ", Locks:\n"
+                 << mgr->toStringWithLines();
     return {ErrorCodes::ERR_LOCK_TIMEOUT, "Lock wait timeout"};
   } else {
     INVARIANT_D(0);
@@ -216,6 +242,10 @@ Expected<std::unique_ptr<KeyLock>> KeyLock::AquireKeyLock(
     if (lock->getLockResult() == mgl::LockRes::LOCKRES_OK) {
       return lock;
     } else if (lock->getLockResult() == mgl::LockRes::LOCKRES_TIMEOUT) {
+      LOG(WARNING) << "Lock wait timeout, key_" << key << " "
+                   << lockModeRepr(mode) << ", threadId:" << getCurThreadId()
+                   << ", Locks:\n"
+                   << mgr->toStringWithLines();
       return {ErrorCodes::ERR_LOCK_TIMEOUT, "Lock wait timeout"};
     } else {
       INVARIANT_D(0);
@@ -244,11 +274,15 @@ KeyLock::KeyLock(uint32_t storeId,
     _lockResult = _parent->getLockResult();
   } else {
     std::string target = "key_" + key;
+    uint64_t sessId = 0;
+    std::string sessType = "";
     if (_sess) {
       _sess->getCtx()->setWaitLock(storeId, chunkId, key, mode);
+      sessId = _sess->id();
+      sessType = _sess->getTypeStr();
     }
     TENDIS_LOCK_LATENCY_RECORD(
-      (_lockResult = _mgl->lock(target, mode, lockTimeoutMs)),
+      (_lockResult = _mgl->lock(target, mode, lockTimeoutMs, sessId, sessType)),
       _sess,
       key,
       LockLatencyType::LLT_KEY);

--- a/src/tendisplus/lock/mgl/mgl.cpp
+++ b/src/tendisplus/lock/mgl/mgl.cpp
@@ -4,6 +4,10 @@
 
 #include "tendisplus/lock/mgl/mgl.h"
 
+#include <cstdio>
+#include <list>
+#include <string>
+
 #include "tendisplus/lock/mgl/mgl_mgr.h"
 #include "tendisplus/utils/invariant.h"
 #include "tendisplus/utils/string.h"
@@ -56,9 +60,13 @@ void MGLock::unlock() {
 
 LockRes MGLock::lock(const std::string& target,
                      LockMode mode,
-                     uint64_t timeoutMs) {
+                     uint64_t timeoutMs,
+                     uint64_t session_id,
+                     std::string session_type) {
   _target = target;
   _mode = mode;
+  _sessionId = session_id;
+  _sessionType = session_type;
   INVARIANT_D(getStatus() == LockRes::LOCKRES_UNINITED);
   _resIter = _dummyList.end();
   if (_target != "") {
@@ -103,13 +111,16 @@ std::string MGLock::toString() const {
   snprintf(buf,
            sizeof(buf),
            "id:%" PRIu64 " target:%s targetHash:%" PRIu64
-           " LockMode:%s LockRes:%d threadId:%s",
+           " LockMode:%s LockRes:%d threadId:%s sessionId:%" PRIu64
+           " sessionType:%s",
            _id,
            _target.c_str(),
            _targetHash,
            lockModeRepr(_mode),
            static_cast<int>(_res),
-           _threadId.c_str());
+           _threadId.c_str(),
+           _sessionId,
+           _sessionType.c_str());
   return std::string(buf);
 }
 

--- a/src/tendisplus/lock/mgl/mgl.h
+++ b/src/tendisplus/lock/mgl/mgl.h
@@ -30,7 +30,11 @@ class MGLock {
   MGLock(MGLock&&) = delete;
   MGLock& operator=(const MGLock&) const = delete;
   ~MGLock();
-  LockRes lock(const std::string& target, LockMode mode, uint64_t timeoutMs);
+  LockRes lock(const std::string& target,
+               LockMode mode,
+               uint64_t timeoutMs,
+               uint64_t session_id,
+               std::string session_type);
   void unlock();
   uint64_t getHash() const {
     return _targetHash;
@@ -67,6 +71,8 @@ class MGLock {
   std::list<MGLock*>::iterator _resIter;
   MGLockMgr* _lockMgr;
   std::string _threadId;
+  uint64_t _sessionId;
+  std::string _sessionType;
 
   static std::atomic<uint64_t> _idGen;
   static std::list<MGLock*> _dummyList;

--- a/src/tendisplus/lock/mgl/mgl_mgr.cpp
+++ b/src/tendisplus/lock/mgl/mgl_mgr.cpp
@@ -4,7 +4,10 @@
 
 #include "tendisplus/lock/mgl/mgl_mgr.h"
 
+#include <list>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "tendisplus/commands/command.h"
 #include "tendisplus/lock/mgl/lock_defines.h"
@@ -223,6 +226,15 @@ std::string MGLockMgr::toString() {
   auto locklist = getLockList();
   for (auto& vs : locklist) {
     ss << vs;
+  }
+  return ss.str();
+}
+
+std::string MGLockMgr::toStringWithLines() {
+  std::stringstream ss;
+  auto locklist = getLockList();
+  for (auto& vs : locklist) {
+    ss << vs << "\n";
   }
   return ss.str();
 }

--- a/src/tendisplus/lock/mgl/mgl_mgr.h
+++ b/src/tendisplus/lock/mgl/mgl_mgr.h
@@ -73,6 +73,7 @@ class MGLockMgr {
   void lock(MGLock* core);
   void unlock(MGLock* core);
   std::string toString();
+  std::string toStringWithLines();
   std::vector<std::string> getLockList();
 
  private:

--- a/src/tendisplus/lock/mgl/mgl_test.cpp
+++ b/src/tendisplus/lock/mgl/mgl_test.cpp
@@ -46,11 +46,15 @@ TEST(LockShard, Align) {
 TEST(MGL, OneTarget) {
   MGLockMgr mgr;
   MGLock l1(&mgr), l2(&mgr), l3(&mgr), l4(&mgr), l5(&mgr);
-  EXPECT_EQ(l1.lock("something", LockMode::LOCK_IS, 1000), LockRes::LOCKRES_OK);
-  EXPECT_EQ(l2.lock("something", LockMode::LOCK_IS, 1000), LockRes::LOCKRES_OK);
-  EXPECT_EQ(l3.lock("something", LockMode::LOCK_IX, 1000), LockRes::LOCKRES_OK);
-  EXPECT_EQ(l4.lock("something", LockMode::LOCK_IX, 1000), LockRes::LOCKRES_OK);
-  EXPECT_EQ(l5.lock("something", LockMode::LOCK_S, 1000),
+  EXPECT_EQ(l1.lock("something", LockMode::LOCK_IS, 1000, 0, ""),
+            LockRes::LOCKRES_OK);
+  EXPECT_EQ(l2.lock("something", LockMode::LOCK_IS, 1000, 0, ""),
+            LockRes::LOCKRES_OK);
+  EXPECT_EQ(l3.lock("something", LockMode::LOCK_IX, 1000, 0, ""),
+            LockRes::LOCKRES_OK);
+  EXPECT_EQ(l4.lock("something", LockMode::LOCK_IX, 1000, 0, ""),
+            LockRes::LOCKRES_OK);
+  EXPECT_EQ(l5.lock("something", LockMode::LOCK_S, 1000, 0, ""),
             LockRes::LOCKRES_TIMEOUT);
   l1.unlock();
   l2.unlock();
@@ -62,8 +66,10 @@ TEST(MGL, OneTarget) {
 TEST(MGL, MultiTarget) {
   MGLockMgr mgr;
   MGLock l1(&mgr), l2(&mgr);
-  EXPECT_EQ(l1.lock("something", LockMode::LOCK_IS, 1000), LockRes::LOCKRES_OK);
-  EXPECT_EQ(l2.lock("something1", LockMode::LOCK_S, 1000), LockRes::LOCKRES_OK);
+  EXPECT_EQ(l1.lock("something", LockMode::LOCK_IS, 1000, 0, ""),
+            LockRes::LOCKRES_OK);
+  EXPECT_EQ(l2.lock("something1", LockMode::LOCK_S, 1000, 0, ""),
+            LockRes::LOCKRES_OK);
   l1.unlock();
   l2.unlock();
 }
@@ -71,12 +77,16 @@ TEST(MGL, MultiTarget) {
 TEST(MGL, MultiThread) {
   MGLockMgr mgr;
   MGLock l1(&mgr), l2(&mgr), l3(&mgr), l4(&mgr), l5(&mgr);
-  EXPECT_EQ(l1.lock("something", LockMode::LOCK_IS, 1000), LockRes::LOCKRES_OK);
-  EXPECT_EQ(l2.lock("something", LockMode::LOCK_IS, 1000), LockRes::LOCKRES_OK);
-  EXPECT_EQ(l3.lock("something", LockMode::LOCK_IX, 1000), LockRes::LOCKRES_OK);
-  EXPECT_EQ(l4.lock("something", LockMode::LOCK_IX, 1000), LockRes::LOCKRES_OK);
+  EXPECT_EQ(l1.lock("something", LockMode::LOCK_IS, 1000, 0, ""),
+            LockRes::LOCKRES_OK);
+  EXPECT_EQ(l2.lock("something", LockMode::LOCK_IS, 1000, 0, ""),
+            LockRes::LOCKRES_OK);
+  EXPECT_EQ(l3.lock("something", LockMode::LOCK_IX, 1000, 0, ""),
+            LockRes::LOCKRES_OK);
+  EXPECT_EQ(l4.lock("something", LockMode::LOCK_IX, 1000, 0, ""),
+            LockRes::LOCKRES_OK);
   std::thread tmp([&l5]() {
-    EXPECT_EQ(l5.lock("something", LockMode::LOCK_S, 10000),
+    EXPECT_EQ(l5.lock("something", LockMode::LOCK_S, 10000, 0, ""),
               LockRes::LOCKRES_OK);
   });
   std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -91,13 +101,14 @@ TEST(MGL, MultiThread) {
 TEST(MGL, Starvation) {
   MGLockMgr mgr;
   MGLock l1(&mgr), l2(&mgr), l3(&mgr);
-  EXPECT_EQ(l1.lock("something", LockMode::LOCK_IS, 1000), LockRes::LOCKRES_OK);
+  EXPECT_EQ(l1.lock("something", LockMode::LOCK_IS, 1000, 0, ""),
+            LockRes::LOCKRES_OK);
   std::thread tmp([&l2]() {
-    EXPECT_EQ(l2.lock("something", LockMode::LOCK_X, 10000),
+    EXPECT_EQ(l2.lock("something", LockMode::LOCK_X, 10000, 0, ""),
               LockRes::LOCKRES_OK);
   });
   std::this_thread::sleep_for(std::chrono::seconds(1));
-  EXPECT_EQ(l3.lock("something", LockMode::LOCK_IX, 1000),
+  EXPECT_EQ(l3.lock("something", LockMode::LOCK_IX, 1000, 0, ""),
             LockRes::LOCKRES_TIMEOUT);
   l1.unlock();
   tmp.join();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
#330
出现“Lock wait timeout”时，打印MGLockMgr中的锁信息列表到日志文件。

## Description
<!--- Describe your changes in detail -->
目前线上遇到一些“ Lock wait timeout”问题，但是无法定位到是谁占用了锁。通过打印锁信息来方便定位相关问题。
目前通过类似“store_7 IX, threadId:140280195892928”字段，可以定位到发起的线程和相关模块。
不过，这还无法定位到具体某一行代码。要实现定位具体哪一行代码，还需要进一步优化。

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Code follows the code style of this project.
- [ ] Change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.