### PR TITLE
support rocks.max_open_files rocks.max_background_jobs in configure file

### DIFF
--- a/src/tendisplus/commands/command_test.cpp
+++ b/src/tendisplus/commands/command_test.cpp
@@ -2286,13 +2286,6 @@ void testRocksOptionCommand(std::shared_ptr<ServerEntry> svr) {
 
   std::stringstream ss;
 
-  sess.setArgs({"CONFIG", "GET", "rocks.max_background_jobs"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  Command::fmtMultiBulkLen(ss, 2);
-  Command::fmtBulk(ss, "rocks.max_background_jobs");
-  Command::fmtBulk(ss, "2");
-  EXPECT_EQ(ss.str(), expect.value());
 
   sess.setArgs({"CONFIG", "SET", "rocks.max_background_jobs", "3"});
   expect = Command::runSessionCmd(&sess);
@@ -2304,24 +2297,6 @@ void testRocksOptionCommand(std::shared_ptr<ServerEntry> svr) {
     auto store = exptDb.value().store;
     EXPECT_EQ(store->getOption("rocks.max_background_jobs"), 3);
   }
-
-  sess.setArgs({"CONFIG", "GET", "rocks.max_background_jobs"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  ss.str("");
-  Command::fmtMultiBulkLen(ss, 2);
-  Command::fmtBulk(ss, "rocks.max_background_jobs");
-  Command::fmtBulk(ss, "3");
-  EXPECT_EQ(ss.str(), expect.value());
-
-  sess.setArgs({"CONFIG", "GET", "rocks.max_open_files"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  ss.str("");
-  Command::fmtMultiBulkLen(ss, 2);
-  Command::fmtBulk(ss, "rocks.max_open_files");
-  Command::fmtBulk(ss, "-1");
-  EXPECT_EQ(ss.str(), expect.value());
 
   sess.setArgs({"CONFIG", "SET", "rocks.max_open_files", "3000"});
   expect = Command::runSessionCmd(&sess);
@@ -2341,26 +2316,6 @@ void testRocksOptionCommand(std::shared_ptr<ServerEntry> svr) {
   Command::fmtMultiBulkLen(ss, 2);
   Command::fmtBulk(ss, "rocks.max_open_files");
   Command::fmtBulk(ss, "3000");
-  EXPECT_EQ(ss.str(), expect.value());
-
-  sess.setArgs({"CONFIG", "SET", "rocks.max_open_files", "-1"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  for (uint32_t i = 0; i < svr->getKVStoreCount(); i++) {
-    auto exptDb = svr->getSegmentMgr()->getDb(&sess, 0, mgl::LockMode::LOCK_IS);
-    EXPECT_TRUE(exptDb.ok());
-
-    auto store = exptDb.value().store;
-    EXPECT_EQ(store->getOption("rocks.max_open_files"), -1);
-  }
-
-  sess.setArgs({"CONFIG", "GET", "rocks.max_open_files"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  ss.str("");
-  Command::fmtMultiBulkLen(ss, 2);
-  Command::fmtBulk(ss, "rocks.max_open_files");
-  Command::fmtBulk(ss, "-1");
   EXPECT_EQ(ss.str(), expect.value());
 
   sess.setArgs({"CONFIG", "SET", "rocks.periodic_compaction_seconds", "3"});

--- a/src/tendisplus/server/server_params.cpp
+++ b/src/tendisplus/server/server_params.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <list>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -33,61 +34,63 @@ std::shared_ptr<tendisplus::ServerParams> gParams;
 std::string gRenameCmdList = "";   // NOLINT(runtime/string)
 std::string gMappingCmdList = "";  // NOLINT(runtime/string)
 
-#define REGISTER_VARS_FULL(                                                   \
-  str, var, checkfun, prefun, minval, maxval, allowDynamicSet)                \
-  if (typeid(var) == typeid(int32_t) || typeid(var) == typeid(uint32_t))      \
-    _mapServerParams.insert(                                                  \
-      make_pair(toLower(str),                                                 \
-                new IntVar(str,                                               \
-                           reinterpret_cast<void*>(&var),                     \
-                           checkfun,                                          \
-                           prefun,                                            \
-                           minval,                                            \
-                           maxval,                                            \
-                           allowDynamicSet)));                                \
-  else if (typeid(var) == typeid(int64_t) || typeid(var) == typeid(uint64_t)) \
-    _mapServerParams.insert(                                                  \
-      make_pair(toLower(str),                                                 \
-                new Int64Var(str,                                             \
-                             reinterpret_cast<void*>(&var),                   \
-                             checkfun,                                        \
-                             prefun,                                          \
-                             minval,                                          \
-                             maxval,                                          \
-                             allowDynamicSet)));                              \
-  else if (typeid(var) == typeid(float))                                      \
-    _mapServerParams.insert(                                                  \
-      make_pair(toLower(str),                                                 \
-                new FloatVar(str,                                             \
-                             reinterpret_cast<void*>(&var),                   \
-                             checkfun,                                        \
-                             prefun,                                          \
-                             allowDynamicSet)));                              \
-  else if (typeid(var) == typeid(double))                                     \
-    _mapServerParams.insert(                                                  \
-      make_pair(toLower(str),                                                 \
-                new DoubleVar(str,                                            \
-                              reinterpret_cast<void*>(&var),                  \
-                              checkfun,                                       \
-                              prefun,                                         \
-                              allowDynamicSet)));                             \
-  else if (typeid(var) == typeid(std::string))                                \
-    _mapServerParams.insert(                                                  \
-      make_pair(toLower(str),                                                 \
-                new StringVar(str,                                            \
-                              reinterpret_cast<void*>(&var),                  \
-                              checkfun,                                       \
-                              prefun,                                         \
-                              allowDynamicSet)));                             \
-  else if (typeid(var) == typeid(bool))                                       \
-    _mapServerParams.insert(                                                  \
-      make_pair(toLower(str),                                                 \
-                new BoolVar(str,                                              \
-                            reinterpret_cast<void*>(&var),                    \
-                            checkfun,                                         \
-                            prefun,                                           \
-                            allowDynamicSet)));                               \
-  else                                                                        \
+#define REGISTER_VARS_FULL(                                    \
+  str, var, checkfun, prefun, minval, maxval, allowDynamicSet) \
+  if (typeid(var) == typeid(int32_t) || /* NOLINT */           \
+      typeid(var) == typeid(uint32_t))  /* NOLINT */           \
+    _mapServerParams.insert(                                   \
+      make_pair(toLower(str),                                  \
+                new IntVar(str,                                \
+                           reinterpret_cast<void*>(&var),      \
+                           checkfun,                           \
+                           prefun,                             \
+                           minval,                             \
+                           maxval,                             \
+                           allowDynamicSet)));                 \
+  else if (typeid(var) == typeid(int64_t) || /* NOLINT */      \
+           typeid(var) == typeid(uint64_t))  /* NOLINT */      \
+    _mapServerParams.insert(                                   \
+      make_pair(toLower(str),                                  \
+                new Int64Var(str,                              \
+                             reinterpret_cast<void*>(&var),    \
+                             checkfun,                         \
+                             prefun,                           \
+                             minval,                           \
+                             maxval,                           \
+                             allowDynamicSet)));               \
+  else if (typeid(var) == typeid(float))                       \
+    _mapServerParams.insert(                                   \
+      make_pair(toLower(str),                                  \
+                new FloatVar(str,                              \
+                             reinterpret_cast<void*>(&var),    \
+                             checkfun,                         \
+                             prefun,                           \
+                             allowDynamicSet)));               \
+  else if (typeid(var) == typeid(double))                      \
+    _mapServerParams.insert(                                   \
+      make_pair(toLower(str),                                  \
+                new DoubleVar(str,                             \
+                              reinterpret_cast<void*>(&var),   \
+                              checkfun,                        \
+                              prefun,                          \
+                              allowDynamicSet)));              \
+  else if (typeid(var) == typeid(std::string))                 \
+    _mapServerParams.insert(                                   \
+      make_pair(toLower(str),                                  \
+                new StringVar(str,                             \
+                              reinterpret_cast<void*>(&var),   \
+                              checkfun,                        \
+                              prefun,                          \
+                              allowDynamicSet)));              \
+  else if (typeid(var) == typeid(bool))                        \
+    _mapServerParams.insert(                                   \
+      make_pair(toLower(str),                                  \
+                new BoolVar(str,                               \
+                            reinterpret_cast<void*>(&var),     \
+                            checkfun,                          \
+                            prefun,                            \
+                            allowDynamicSet)));                \
+  else                                                         \
     INVARIANT(0);  // NOTE(takenliu): if other type is needed, change here.
 
 static const char* NO_USE_VALUE = "NO_USE";
@@ -494,10 +497,6 @@ ServerParams::ServerParams() {
   REGISTER_VARS_DIFF_NAME("rocks.level0_compress_enabled", level0Compress);
   REGISTER_VARS_DIFF_NAME("rocks.level1_compress_enabled", level1Compress);
 
-  REGISTER_VARS_FULL(
-    "rocks.max_open_files", rocksMaxOpenFiles, NULL, NULL, -1, INT_MAX, true);
-  REGISTER_VARS_DIFF_NAME_DYNAMIC("rocks.max_background_jobs",
-                                  rocksMaxBackgroundJobs);
   REGISTER_VARS_DIFF_NAME_DYNAMIC("rocks.compaction_deletes_window",
                                   rocksCompactOnDeletionWindow);
   REGISTER_VARS_DIFF_NAME_DYNAMIC("rocks.compaction_deletes_trigger",

--- a/src/tendisplus/server/server_params.h
+++ b/src/tendisplus/server/server_params.h
@@ -551,8 +551,6 @@ class ServerParams {
   bool rocksStrictCapacityLimit = false;
   std::string rocksWALDir = "";
   std::string rocksCompressType = "snappy";
-  int32_t rocksMaxOpenFiles = -1;
-  int32_t rocksMaxBackgroundJobs = 2;
   uint32_t rocksCompactOnDeletionWindow = 0;
   uint32_t rocksCompactOnDeletionTrigger = 0;
   double rocksCompactOnDeletionRatio = 0;


### PR DESCRIPTION
## 描述

#310 
修复配置文件里面配置rocks.max_open_files，rocks.max_background_jobs，不能生效

## 仍然存在的问题

如果rocksdb的参数未在配置文件中配置或者未执行过config set，则config get不能获取。