### PR TITLE
execute bitsetEncodeVec only when slots changes, otherwise get the _mySlotsVec directly 

### DIFF
--- a/src/tendisplus/cluster/cluster_manager.cpp
+++ b/src/tendisplus/cluster/cluster_manager.cpp
@@ -555,6 +555,14 @@ std::bitset<CLUSTER_SLOTS> ClusterNode::getSlots() const {
   std::lock_guard<myMutex> lk(_mutex);
   return _mySlots;
 }
+// Now the function is only called by ClusterState::clusterSaveNodes()
+std::vector<uint16_t> ClusterNode::getSlotsVec() {
+  std::lock_guard<myMutex> lk(_mutex);
+  if (_slotsInfoIsOutOfDate) {
+    _mySlotsVec = std::move(bitsetEncodeVec(_mySlots));
+  }
+  return _mySlotsVec;
+}
 
 uint32_t ClusterNode::getSlavesCount() const {
   std::lock_guard<myMutex> lk(_mutex);
@@ -1680,9 +1688,7 @@ Status ClusterState::clusterSaveNodes() {
     std::string masterName =
       (node->getMaster()) ? node->getMaster()->getNodeName() : "-";
 
-    std::bitset<CLUSTER_SLOTS> slots = node->getSlots();
-
-    auto slotBuff = std::move(bitsetEncodeVec(slots));
+    auto slotBuff = node->getSlotsVec();
 
     auto meta = std::make_unique<ClusterMeta>(node->getNodeName(),
                                               node->getNodeIp(),

--- a/src/tendisplus/cluster/cluster_manager.h
+++ b/src/tendisplus/cluster/cluster_manager.h
@@ -140,6 +140,7 @@ class ClusterNode : public std::enable_shared_from_this<ClusterNode> {
   void setNodeCport(uint64_t cport);
 
   std::bitset<CLUSTER_SLOTS> getSlots() const;
+  std::vector<uint16_t> getSlotsVec();
 
   uint32_t getSlavesCount() const;
 
@@ -246,7 +247,8 @@ class ClusterNode : public std::enable_shared_from_this<ClusterNode> {
   std::shared_ptr<BlockingTcpClient> _nodeClient;
   // slots handled by this node
   std::bitset<CLUSTER_SLOTS> _mySlots;
-  std::string _slotsInfo;  // string info of _mySlots
+  std::vector<uint16_t> _mySlotsVec;  // vector of slots for fast access
+  std::string _slotsInfo;             // string info of _mySlots
   bool _slotsInfoIsOutOfDate;
   uint16_t _numSlaves;
   uint32_t _numSlots;
@@ -573,8 +575,8 @@ class ClusterState : public std::enable_shared_from_this<ClusterState> {
                          const std::string& newname,
                          bool save = false);
   void clusterRenameNodeNoLock(CNodePtr node,
-                         const std::string& newname,
-                         bool save = false);
+                               const std::string& newname,
+                               bool save = false);
 
   bool clusterSetNodeAsMaster(CNodePtr node);
   bool clusterSetNodeAsMasterNoLock(CNodePtr node);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
#337 
bitsetEncodeVec 函数性能消耗较大，是用来获取cluseterNode节点的slots信息，不需要每次都重新编码，只需要在slots改变之后才编码。