### PR TITLE
fix some bug in rocks options

### DIFF
--- a/src/tendisplus/cluster/migrate_manager.cpp
+++ b/src/tendisplus/cluster/migrate_manager.cpp
@@ -5,6 +5,8 @@
 #include "tendisplus/cluster/migrate_manager.h"
 
 #include <algorithm>
+#include <list>
+#include <map>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -105,13 +107,17 @@ MigrateManager::MigrateManager(std::shared_ptr<ServerEntry> svr,
     _workload(0),
     _rateLimiter(
       std::make_unique<RateLimiter>(_cfg->migrateRateLimitMB * 1024 * 1024)) {
-  _cfg->serverParamsVar("migrateSenderThreadnum")->setUpdate([this]() {
-    migrateSenderResize(_cfg->migrateSenderThreadnum);
-  });
+  _cfg->serverParamsVar("migrateSenderThreadnum")
+    ->setUpdate([this]() -> Status {
+      migrateSenderResize(_cfg->migrateSenderThreadnum);
+      return {ErrorCodes::ERR_OK, ""};
+    });
 
-  _cfg->serverParamsVar("migrateReceiveThreadnum")->setUpdate([this]() {
-    migrateReceiverResize(_cfg->migrateReceiveThreadnum);
-  });
+  _cfg->serverParamsVar("migrateReceiveThreadnum")
+    ->setUpdate([this]() -> Status {
+      migrateReceiverResize(_cfg->migrateReceiveThreadnum);
+      return {ErrorCodes::ERR_OK, ""};
+    });
 }
 
 Status MigrateManager::startup() {
@@ -720,12 +726,12 @@ bool MigrateManager::containSlot(const SlotsBitmap& smallMap,
   return true;
 }
 
-void MigrateManager::requestRateLimit(uint64_t bytes) {
+void MigrateManager::requestRateLimit(uint64_t bytes) {  // NOLINT
   /* *
    * Set migration rate limit periodically
    */
-  _rateLimiter->SetBytesPerSecond((uint64_t)_cfg->migrateRateLimitMB * 1024 *
-                                  1024);
+  _rateLimiter->SetBytesPerSecond(
+    static_cast<uint64_t>(_cfg->migrateRateLimitMB) * 1024 * 1024);
   _rateLimiter->Request(bytes);
 }
 
@@ -1505,13 +1511,11 @@ Expected<std::string> MigrateManager::getMigrateInfoStr(
   std::lock_guard<myMutex> lk(_mutex);
   for (auto iter = _migrateNodes.begin(); iter != _migrateNodes.end(); ++iter) {
     if (slots.test(iter->first)) {
-      stream1 << "[" << iter->first << "->-" << iter->second << "]"
-              << " ";
+      stream1 << "[" << iter->first << "->-" << iter->second << "]" << " ";
     }
   }
   for (auto iter = _importNodes.begin(); iter != _importNodes.end(); ++iter) {
-    stream2 << "[" << iter->first << "-<-" << iter->second << "]"
-            << " ";
+    stream2 << "[" << iter->first << "-<-" << iter->second << "]" << " ";
   }
   if (stream1.str().size() == 0 && stream2.str().size() == 0) {
     return {ErrorCodes::ERR_CLUSTER, "no migrate or import slots"};

--- a/src/tendisplus/commands/command_test.cpp
+++ b/src/tendisplus/commands/command_test.cpp
@@ -2286,14 +2286,6 @@ void testRocksOptionCommand(std::shared_ptr<ServerEntry> svr) {
 
   std::stringstream ss;
 
-  sess.setArgs({"CONFIG", "GET", "rocks.max_background_jobs"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  Command::fmtMultiBulkLen(ss, 2);
-  Command::fmtBulk(ss, "rocks.max_background_jobs");
-  Command::fmtBulk(ss, "2");
-  EXPECT_EQ(ss.str(), expect.value());
-
   sess.setArgs({"CONFIG", "SET", "rocks.max_background_jobs", "3"});
   expect = Command::runSessionCmd(&sess);
   EXPECT_TRUE(expect.ok());
@@ -2312,15 +2304,6 @@ void testRocksOptionCommand(std::shared_ptr<ServerEntry> svr) {
   Command::fmtMultiBulkLen(ss, 2);
   Command::fmtBulk(ss, "rocks.max_background_jobs");
   Command::fmtBulk(ss, "3");
-  EXPECT_EQ(ss.str(), expect.value());
-
-  sess.setArgs({"CONFIG", "GET", "rocks.max_open_files"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  ss.str("");
-  Command::fmtMultiBulkLen(ss, 2);
-  Command::fmtBulk(ss, "rocks.max_open_files");
-  Command::fmtBulk(ss, "-1");
   EXPECT_EQ(ss.str(), expect.value());
 
   sess.setArgs({"CONFIG", "SET", "rocks.max_open_files", "3000"});

--- a/src/tendisplus/replication/repl_manager.cpp
+++ b/src/tendisplus/replication/repl_manager.cpp
@@ -94,17 +94,21 @@ ReplManager::ReplManager(std::shared_ptr<ServerEntry> svr,
     _incrCheckMatrix(std::make_shared<PoolMatrix>()),
     _logRecycleMatrix(std::make_shared<PoolMatrix>()),
     _connectMasterTimeoutMs(1000) {
-  _cfg->serverParamsVar("incrPushThreadnum")->setUpdate([this]() {
+  _cfg->serverParamsVar("incrPushThreadnum")->setUpdate([this]() -> Status {
     incrPusherResize(_cfg->incrPushThreadnum);
+    return {ErrorCodes::ERR_OK, ""};
   });
-  _cfg->serverParamsVar("fullPushThreadnum")->setUpdate([this]() {
+  _cfg->serverParamsVar("fullPushThreadnum")->setUpdate([this]() -> Status {
     fullPusherResize(_cfg->fullPushThreadnum);
+    return {ErrorCodes::ERR_OK, ""};
   });
-  _cfg->serverParamsVar("fullReceiveThreadnum")->setUpdate([this]() {
+  _cfg->serverParamsVar("fullReceiveThreadnum")->setUpdate([this]() -> Status {
     fullReceiverResize(_cfg->fullReceiveThreadnum);
+    return {ErrorCodes::ERR_OK, ""};
   });
-  _cfg->serverParamsVar("logRecycleThreadnum")->setUpdate([this]() {
+  _cfg->serverParamsVar("logRecycleThreadnum")->setUpdate([this]() -> Status {
     logRecyclerResize(_cfg->logRecycleThreadnum);
+    return {ErrorCodes::ERR_OK, ""};
   });
 }
 

--- a/src/tendisplus/server/index_manager.cpp
+++ b/src/tendisplus/server/index_manager.cpp
@@ -39,11 +39,13 @@ IndexManager::IndexManager(std::shared_ptr<ServerEntry> svr,
     _delJobCnt[storeId] = {0u};
   }
 
-  _cfg->serverParamsVar("scanJobCntIndexMgr")->setUpdate([this]() {
+  _cfg->serverParamsVar("scanJobCntIndexMgr")->setUpdate([this]() -> Status {
     indexScannerResize(_cfg->scanJobCntIndexMgr);
+    return {ErrorCodes::ERR_OK, ""};
   });
-  _cfg->serverParamsVar("delJobCntIndexMgr")->setUpdate([this]() {
+  _cfg->serverParamsVar("delJobCntIndexMgr")->setUpdate([this]() -> Status {
     keyDeleterResize(_cfg->delJobCntIndexMgr);
+    return {ErrorCodes::ERR_OK, ""};
   });
 }
 
@@ -110,7 +112,7 @@ std::string IndexManager::getInfoString() {
   uint64_t minttl = -1;
 
   auto ttlStr = [](uint64_t ttl) {
-    if (ttl == (uint64_t)-1) {
+    if (ttl == static_cast<uint64_t>(-1)) {
       return std::to_string(-1);
     } else {
       return msEpochToDatetime(ttl);
@@ -123,8 +125,7 @@ std::string IndexManager::getInfoString() {
       minttl = _scanPonitsTtl[i];
     }
   }
-  ss << "scanpoint"
-     << ":" << ttlStr(minttl) << "\r\n";
+  ss << "scanpoint" << ":" << ttlStr(minttl) << "\r\n";
 
   return ss.str();
 }

--- a/src/tendisplus/server/server_entry.cpp
+++ b/src/tendisplus/server/server_entry.cpp
@@ -22,6 +22,8 @@
 #endif
 #endif
 
+#include "rocksdb/tendis_extension.h"
+
 #include "tendisplus/commands/command.h"
 #include "tendisplus/lock/lock.h"
 #include "tendisplus/network/latency_record.h"
@@ -382,6 +384,22 @@ ServerEntry::ServerEntry()
     _internalErrorCnt(0),
     _lastBackupFailedErr("") {}
 
+Status ServerEntry::updateCompactDeletion(
+  std::string name, std::shared_ptr<tendisplus::ServerParams> cfg) {
+  auto server = getGlobalServer();
+  LocalSessionGuard sg(server.get());
+  for (uint64_t i = 0; i < server->getKVStoreCount(); i++) {
+    auto expStore = server->getSegmentMgr()->getDb(
+      sg.getSession(), i, mgl::LockMode::LOCK_IS);
+    RET_IF_ERR_EXPECTED(expStore);
+    Status s;
+    // change rockdb options.CompactOnDeletionTableFactory
+    s = expStore.value().store->setCompactOnDeletionCollectorFactory(name, cfg);
+    RET_IF_ERR(s);
+  }
+  return {ErrorCodes::ERR_OK, ""};
+}
+
 ServerEntry::ServerEntry(const std::shared_ptr<ServerParams>& cfg)
   : ServerEntry() {
   _requirepass = cfg->requirepass;
@@ -391,20 +409,42 @@ ServerEntry::ServerEntry(const std::shared_ptr<ServerParams>& cfg)
   _dbNum = cfg->dbNum;
   _cfg = cfg;
   // set callback function when dynamically changing option
-  _cfg->serverParamsVar("executorThreadNum")->setUpdate([this]() {
+  _cfg->serverParamsVar("executorThreadNum")->setUpdate([this]() -> Status {
     if (_cfg->executorThreadNum !=
         _executorList.size() * _executorList.back()->size()) {
       _newExecutorThreadNum.store(_cfg->executorThreadNum);
     }
+    return {ErrorCodes::ERR_OK, ""};
   });
 #ifdef TENDIS_JEMALLOC
-  _cfg->serverParamsVar("enable-jemalloc-bgthread")->setUpdate([this]() {
-    jemallocBgThreadConf();
-  });
+  _cfg->serverParamsVar("enable-jemalloc-bgthread")
+    ->setUpdate([this]() -> Status {
+      jemallocBgThreadConf();
+      return {ErrorCodes::ERR_OK, ""};
+    });
 #endif
   _cfg->serverParamsVar("rocks.rate_limiter_rate_bytes_per_sec")
-    ->setUpdate(
-      [this]() { updateRateLimiter(_cfg->rocksRateLimiterRateBytesPerSec); });
+    ->setUpdate([this]() -> Status {
+      updateRateLimiter(_cfg->rocksRateLimiterRateBytesPerSec);
+      return {ErrorCodes::ERR_OK, ""};
+    });
+
+  _cfg->serverParamsVar("rocks.latency-limit")->setUpdate([this]() -> Status {
+    rocksdb::G_ROCKSDB_LATENCY_LIMIT = _cfg->rocksdbLatencyLimit;
+    return {ErrorCodes::ERR_OK, ""};
+  });
+  _cfg->serverParamsVar("rocks.compaction_deletes_window")
+    ->setUpdate([this]() -> Status {
+      return updateCompactDeletion("rocks.compaction_deletes_window", _cfg);
+    });
+  _cfg->serverParamsVar("rocks.compaction_deletes_trigger")
+    ->setUpdate([this]() -> Status {
+      return updateCompactDeletion("rocks.compaction_deletes_trigger", _cfg);
+    });
+  _cfg->serverParamsVar("rocks.compaction_deletes_ratio")
+    ->setUpdate([this]() -> Status {
+      return updateCompactDeletion("rocks.compaction_deletes_ratio", _cfg);
+    });
 }
 
 ServerEntry::~ServerEntry() {

--- a/src/tendisplus/server/server_entry.h
+++ b/src/tendisplus/server/server_entry.h
@@ -418,6 +418,8 @@ class ServerEntry : public std::enable_shared_from_this<ServerEntry> {
   void serverCron();
   void jeprofCron();
   void jemallocBgThreadConf();
+  Status updateCompactDeletion(std::string name,
+                               std::shared_ptr<tendisplus::ServerParams> cfg);
   void replyMonitors(Session* sess);
   void DelMonitorNoLock(uint64_t connId);
   void DelSubSession(uint64_t connId);

--- a/src/tendisplus/server/server_params.cpp
+++ b/src/tendisplus/server/server_params.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <list>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -33,61 +34,63 @@ std::shared_ptr<tendisplus::ServerParams> gParams;
 std::string gRenameCmdList = "";   // NOLINT(runtime/string)
 std::string gMappingCmdList = "";  // NOLINT(runtime/string)
 
-#define REGISTER_VARS_FULL(                                                   \
-  str, var, checkfun, prefun, minval, maxval, allowDynamicSet)                \
-  if (typeid(var) == typeid(int32_t) || typeid(var) == typeid(uint32_t))      \
-    _mapServerParams.insert(                                                  \
-      make_pair(toLower(str),                                                 \
-                new IntVar(str,                                               \
-                           reinterpret_cast<void*>(&var),                     \
-                           checkfun,                                          \
-                           prefun,                                            \
-                           minval,                                            \
-                           maxval,                                            \
-                           allowDynamicSet)));                                \
-  else if (typeid(var) == typeid(int64_t) || typeid(var) == typeid(uint64_t)) \
-    _mapServerParams.insert(                                                  \
-      make_pair(toLower(str),                                                 \
-                new Int64Var(str,                                             \
-                             reinterpret_cast<void*>(&var),                   \
-                             checkfun,                                        \
-                             prefun,                                          \
-                             minval,                                          \
-                             maxval,                                          \
-                             allowDynamicSet)));                              \
-  else if (typeid(var) == typeid(float))                                      \
-    _mapServerParams.insert(                                                  \
-      make_pair(toLower(str),                                                 \
-                new FloatVar(str,                                             \
-                             reinterpret_cast<void*>(&var),                   \
-                             checkfun,                                        \
-                             prefun,                                          \
-                             allowDynamicSet)));                              \
-  else if (typeid(var) == typeid(double))                                     \
-    _mapServerParams.insert(                                                  \
-      make_pair(toLower(str),                                                 \
-                new DoubleVar(str,                                            \
-                              reinterpret_cast<void*>(&var),                  \
-                              checkfun,                                       \
-                              prefun,                                         \
-                              allowDynamicSet)));                             \
-  else if (typeid(var) == typeid(std::string))                                \
-    _mapServerParams.insert(                                                  \
-      make_pair(toLower(str),                                                 \
-                new StringVar(str,                                            \
-                              reinterpret_cast<void*>(&var),                  \
-                              checkfun,                                       \
-                              prefun,                                         \
-                              allowDynamicSet)));                             \
-  else if (typeid(var) == typeid(bool))                                       \
-    _mapServerParams.insert(                                                  \
-      make_pair(toLower(str),                                                 \
-                new BoolVar(str,                                              \
-                            reinterpret_cast<void*>(&var),                    \
-                            checkfun,                                         \
-                            prefun,                                           \
-                            allowDynamicSet)));                               \
-  else                                                                        \
+#define REGISTER_VARS_FULL(                                    \
+  str, var, checkfun, prefun, minval, maxval, allowDynamicSet) \
+  if (typeid(var) == typeid(int32_t) || /* NOLINT */           \
+      typeid(var) == typeid(uint32_t))  /* NOLINT */           \
+    _mapServerParams.insert(                                   \
+      make_pair(toLower(str),                                  \
+                new IntVar(str,                                \
+                           reinterpret_cast<void*>(&var),      \
+                           checkfun,                           \
+                           prefun,                             \
+                           minval,                             \
+                           maxval,                             \
+                           allowDynamicSet)));                 \
+  else if (typeid(var) == typeid(int64_t) || /* NOLINT */      \
+           typeid(var) == typeid(uint64_t))  /* NOLINT */      \
+    _mapServerParams.insert(                                   \
+      make_pair(toLower(str),                                  \
+                new Int64Var(str,                              \
+                             reinterpret_cast<void*>(&var),    \
+                             checkfun,                         \
+                             prefun,                           \
+                             minval,                           \
+                             maxval,                           \
+                             allowDynamicSet)));               \
+  else if (typeid(var) == typeid(float))                       \
+    _mapServerParams.insert(                                   \
+      make_pair(toLower(str),                                  \
+                new FloatVar(str,                              \
+                             reinterpret_cast<void*>(&var),    \
+                             checkfun,                         \
+                             prefun,                           \
+                             allowDynamicSet)));               \
+  else if (typeid(var) == typeid(double))                      \
+    _mapServerParams.insert(                                   \
+      make_pair(toLower(str),                                  \
+                new DoubleVar(str,                             \
+                              reinterpret_cast<void*>(&var),   \
+                              checkfun,                        \
+                              prefun,                          \
+                              allowDynamicSet)));              \
+  else if (typeid(var) == typeid(std::string))                 \
+    _mapServerParams.insert(                                   \
+      make_pair(toLower(str),                                  \
+                new StringVar(str,                             \
+                              reinterpret_cast<void*>(&var),   \
+                              checkfun,                        \
+                              prefun,                          \
+                              allowDynamicSet)));              \
+  else if (typeid(var) == typeid(bool))                        \
+    _mapServerParams.insert(                                   \
+      make_pair(toLower(str),                                  \
+                new BoolVar(str,                               \
+                            reinterpret_cast<void*>(&var),     \
+                            checkfun,                          \
+                            prefun,                            \
+                            allowDynamicSet)));                \
+  else                                                         \
     INVARIANT(0);  // NOTE(takenliu): if other type is needed, change here.
 
 static const char* NO_USE_VALUE = "NO_USE";
@@ -494,10 +497,6 @@ ServerParams::ServerParams() {
   REGISTER_VARS_DIFF_NAME("rocks.level0_compress_enabled", level0Compress);
   REGISTER_VARS_DIFF_NAME("rocks.level1_compress_enabled", level1Compress);
 
-  REGISTER_VARS_FULL(
-    "rocks.max_open_files", rocksMaxOpenFiles, NULL, NULL, -1, INT_MAX, true);
-  REGISTER_VARS_DIFF_NAME_DYNAMIC("rocks.max_background_jobs",
-                                  rocksMaxBackgroundJobs);
   REGISTER_VARS_DIFF_NAME_DYNAMIC("rocks.compaction_deletes_window",
                                   rocksCompactOnDeletionWindow);
   REGISTER_VARS_DIFF_NAME_DYNAMIC("rocks.compaction_deletes_trigger",
@@ -794,6 +793,23 @@ Status ServerParams::setRocksOption(const std::string& argname,
     return {ErrorCodes::ERR_OK, ""};
   }
 }
+
+Status ServerParams::setRocksOptionDynamic(const std::string& argname,
+                                           const std::string& value) {
+  auto server = getGlobalServer();
+  LocalSessionGuard sg(server.get());
+  for (uint64_t i = 0; i < server->getKVStoreCount(); i++) {
+    auto expStore = server->getSegmentMgr()->getDb(
+      sg.getSession(), i, mgl::LockMode::LOCK_IS);
+    RET_IF_ERR_EXPECTED(expStore);
+
+    Status s;
+    // change rocksdb options dynamically
+    s = expStore.value().store->setOptionDynamic(argname, value);
+    RET_IF_ERR(s);
+  }
+  return {ErrorCodes::ERR_OK, ""};
+}
 Status ServerParams::setVar(const std::string& name,
                             const std::string& value,
                             bool startup) {
@@ -806,54 +822,17 @@ Status ServerParams::setVar(const std::string& name,
     if (iter == _mapServerParams.end()) {
       return setRocksOption(argname, value);
     } else {
-      if (argname == "rocks.latency-limit") {
-        auto ed = tendisplus::stoll(value);
-        if (!ed.ok()) {
-          errinfo = "invalid rocksdb options:" + argname + " value:" + value +
-            " " + ed.status().toString();
-          return {ErrorCodes::ERR_PARSEOPT, errinfo};
-        }
-        rocksdb::G_ROCKSDB_LATENCY_LIMIT = ed.value();
-      }
       return iter->second->setVar(value, startup);
     }
   } else {
     // change serverparam and rocksoptions when running
-    if (argname.substr(0, 6) == "rocks.") {
-      if (argname == "rocks.latency-limit") {
-        auto ed = tendisplus::stoll(value);
-        if (!ed.ok()) {
-          errinfo = "invalid rocksdb options:" + argname + " value:" + value +
-            " " + ed.status().toString();
-          return {ErrorCodes::ERR_PARSEOPT, errinfo};
-        }
-        rocksdb::G_ROCKSDB_LATENCY_LIMIT = ed.value();
-        return {ErrorCodes::ERR_OK, ""};
-      }
-      // make sure changed RocksdbOptions take effect when KVstore is running
-      auto server = getGlobalServer();
-      LocalSessionGuard sg(server.get());
-      for (uint64_t i = 0; i < server->getKVStoreCount(); i++) {
-        auto expStore = server->getSegmentMgr()->getDb(
-          sg.getSession(), i, mgl::LockMode::LOCK_IS);
-        RET_IF_ERR_EXPECTED(expStore);
-
-        Status s;
-        // change rocksdb options dynamically
-        if (argname.substr(0, 25) == "rocks.compaction_deletes_") {
-          // change rockdb options.CompactOnDeletionTableFactory
-          s = expStore.value().store->setCompactOnDeletionCollectorFactory(
-            argname, value);
-        } else {
-          s = expStore.value().store->setOptionDynamic(argname, value);
-        }
-        RET_IF_ERR(s);
-      }
-    }
-
     LOG(INFO) << "ServerParams setVar dynamic, " << argname << ": " << value;
     if (iter == _mapServerParams.end()) {
-      return setRocksOption(argname, value);
+      if (argname.substr(0, 6) == "rocks.") {
+        Status s = setRocksOptionDynamic(argname, value);
+        RET_IF_ERR(s);
+        return setRocksOption(argname, value);
+      }
     } else {
       return iter->second->setVar(value, startup);
     }

--- a/src/tendisplus/server/server_params.h
+++ b/src/tendisplus/server/server_params.h
@@ -28,7 +28,7 @@
 
 namespace tendisplus {
 
-using funptr = std::function<void()>;
+using funptr = std::function<Status()>;
 using checkfunptr =
   std::function<bool(const std::string&, bool startup, std::string* errinfo)>;
 using preProcess = std::function<std::string(const std::string&)>;
@@ -130,8 +130,10 @@ class StringVar : public BaseVar {
 
     *reinterpret_cast<std::string*>(value) = v;
 
-    if (Onupdate != NULL)
-      Onupdate();
+    if (Onupdate != NULL) {
+      return Onupdate();
+    }
+
     return {ErrorCodes::ERR_OK, ""};
   }
   std::string _defaultValue;
@@ -176,8 +178,9 @@ class IntVar : public BaseVar {
     }
     *reinterpret_cast<int*>(value) = valTemp;
 
-    if (Onupdate != NULL)
-      Onupdate();
+    if (Onupdate != NULL) {
+      return Onupdate();
+    }
 
     return {ErrorCodes::ERR_OK, ""};
   }
@@ -225,8 +228,9 @@ class Int64Var : public BaseVar {
     }
     *reinterpret_cast<int64_t*>(value) = valTemp;
 
-    if (Onupdate != NULL)
-      Onupdate();
+    if (Onupdate != NULL) {
+      return Onupdate();
+    }
 
     return {ErrorCodes::ERR_OK, ""};
   }
@@ -265,8 +269,9 @@ class FloatVar : public BaseVar {
     }
     *reinterpret_cast<float*>(value) = static_cast<float>(eFloat.value());
 
-    if (Onupdate != NULL)
-      Onupdate();
+    if (Onupdate != NULL) {
+      return Onupdate();
+    }
     return {ErrorCodes::ERR_OK, ""};
   }
   float _defaultValue;
@@ -302,8 +307,9 @@ class DoubleVar : public BaseVar {
     }
     *reinterpret_cast<double*>(value) = static_cast<double>(eDouble.value());
 
-    if (Onupdate != NULL)
-      Onupdate();
+    if (Onupdate != NULL) {
+      return Onupdate();
+    }
     return {ErrorCodes::ERR_OK, ""};
   }
   double _defaultValue;
@@ -335,8 +341,9 @@ class BoolVar : public BaseVar {
 
     *reinterpret_cast<bool*>(value) = isOptionOn(v);
 
-    if (Onupdate != NULL)
-      Onupdate();
+    if (Onupdate != NULL) {
+      return Onupdate();
+    }
     return {ErrorCodes::ERR_OK, ""};
   }
   bool _defaultValue;
@@ -406,6 +413,8 @@ class ServerParams {
   bool showVar(const std::string& key, std::string* info) const;
   bool showVar(const std::string& key, std::vector<std::string>* info) const;
   Status setRocksOption(const std::string& name, const std::string& value);
+  Status setRocksOptionDynamic(const std::string& argname,
+                               const std::string& value);
   Status setVar(const std::string& name,
                 const std::string& value,
                 bool startup = true);
@@ -551,8 +560,6 @@ class ServerParams {
   bool rocksStrictCapacityLimit = false;
   std::string rocksWALDir = "";
   std::string rocksCompressType = "snappy";
-  int32_t rocksMaxOpenFiles = -1;
-  int32_t rocksMaxBackgroundJobs = 2;
   uint32_t rocksCompactOnDeletionWindow = 0;
   uint32_t rocksCompactOnDeletionTrigger = 0;
   double rocksCompactOnDeletionRatio = 0;

--- a/src/tendisplus/server/server_params_test.cpp
+++ b/src/tendisplus/server/server_params_test.cpp
@@ -4,6 +4,7 @@
 
 #include <fstream>
 #include <memory>
+#include <string>
 
 #include "gtest/gtest.h"
 
@@ -15,8 +16,9 @@
 namespace tendisplus {
 
 int paramUpdateValue = 0;
-void paramOnUpdate() {
+Status paramOnUpdate() {
   paramUpdateValue = 1;
+  return {ErrorCodes::ERR_OK, ""};
 }
 
 TEST(ServerParams, Common) {

--- a/src/tendisplus/storage/kvstore.h
+++ b/src/tendisplus/storage/kvstore.h
@@ -354,7 +354,7 @@ struct TruncateBinlogResult {
   uint64_t written;
   int32_t err;
 };
-
+class ServerParams;
 class KVStore {
  public:
   enum class StoreMode { READ_WRITE = 0, REPLICATE_ONLY = 1, STORE_NONE = 2 };
@@ -504,7 +504,8 @@ class KVStore {
   virtual Status setOptionDynamic(const std::string& option,
                                   const std::string& value) = 0;
   virtual Status setCompactOnDeletionCollectorFactory(
-    const std::string& option, const std::string& value) = 0;
+    const std::string& option,
+    std::shared_ptr<tendisplus::ServerParams> cfg) = 0;
   virtual int64_t getOption(const std::string& option) = 0;
 
   KVStoreStat stat;

--- a/src/tendisplus/storage/rocks/rocks_kvstore.cpp
+++ b/src/tendisplus/storage/rocks/rocks_kvstore.cpp
@@ -5,12 +5,15 @@
 #include "tendisplus/storage/rocks/rocks_kvstore.h"
 
 #include <algorithm>
+#include <iostream>
 #include <limits>
 #include <list>
 #include <map>
 #include <memory>
+#include <set>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -1027,19 +1030,19 @@ Status rocksdbOptionsSet(
   } else if (key == "level0_stop_writes_trigger") {
     options.level0_stop_writes_trigger = static_cast<int>(value);
   } else if (key == "target_file_size_base") {
-    options.target_file_size_base = (uint64_t)value;
+    options.target_file_size_base = static_cast<uint64_t>(value);
   } else if (key == "target_file_size_multiplier") {
     options.target_file_size_multiplier = static_cast<int>(value);
   } else if (key == "level_compaction_dynamic_level_bytes") {
     options.level_compaction_dynamic_level_bytes = static_cast<bool>(value);
   } else if (key == "max_compaction_bytes") {
-    options.max_compaction_bytes = (uint64_t)value;
+    options.max_compaction_bytes = static_cast<uint64_t>(value);
   } else if (key == "soft_pending_compaction_bytes_limit") {
-    options.soft_pending_compaction_bytes_limit = (uint64_t)value;
+    options.soft_pending_compaction_bytes_limit = static_cast<uint64_t>(value);
   } else if (key == "hard_pending_compaction_bytes_limit") {
-    options.hard_pending_compaction_bytes_limit = (uint64_t)value;
+    options.hard_pending_compaction_bytes_limit = static_cast<uint64_t>(value);
   } else if (key == "max_sequential_skip_in_iterations") {
-    options.max_sequential_skip_in_iterations = (uint64_t)value;
+    options.max_sequential_skip_in_iterations = static_cast<uint64_t>(value);
   } else if (key == "max_successive_merges") {
     options.max_successive_merges = static_cast<size_t>(value);
   } else if (key == "optimize_filters_for_hits") {
@@ -1052,14 +1055,14 @@ Status rocksdbOptionsSet(
     options.report_bg_io_stats = static_cast<bool>(value);
 #if ROCKSDB_MAJOR > 5 || (ROCKSDB_MAJOR == 5 && ROCKSDB_MINOR > 15)
   } else if (key == "ttl") {
-    options.ttl = (uint64_t)value;
+    options.ttl = static_cast<uint64_t>(value);
 #endif
   } else if (key == "write_buffer_size") {
     options.write_buffer_size = static_cast<size_t>(value);
   } else if (key == "level0_file_num_compaction_trigger") {
     options.level0_file_num_compaction_trigger = static_cast<int>(value);
   } else if (key == "max_bytes_for_level_base") {
-    options.max_bytes_for_level_base = (uint64_t)value;
+    options.max_bytes_for_level_base = static_cast<uint64_t>(value);
   } else if (key == "disable_auto_compactions") {
     options.disable_auto_compactions = static_cast<bool>(value);
   } else if (key == "create_if_missing") {
@@ -1077,11 +1080,11 @@ Status rocksdbOptionsSet(
   } else if (key == "max_file_opening_threads") {
     options.max_file_opening_threads = static_cast<int>(value);
   } else if (key == "max_total_wal_size") {
-    options.max_total_wal_size = (uint64_t)value;
+    options.max_total_wal_size = static_cast<uint64_t>(value);
   } else if (key == "use_fsync") {
     options.use_fsync = static_cast<bool>(value);
   } else if (key == "delete_obsolete_files_period_micros") {
-    options.delete_obsolete_files_period_micros = (uint64_t)value;
+    options.delete_obsolete_files_period_micros = static_cast<uint64_t>(value);
   } else if (key == "max_background_jobs") {
     options.max_background_jobs = static_cast<int>(value);
   } else if (key == "max_subcompactions") {
@@ -1095,13 +1098,13 @@ Status rocksdbOptionsSet(
   } else if (key == "recycle_log_file_num") {
     options.recycle_log_file_num = static_cast<size_t>(value);
   } else if (key == "max_manifest_file_size") {
-    options.max_manifest_file_size = (uint64_t)value;
+    options.max_manifest_file_size = static_cast<uint64_t>(value);
   } else if (key == "table_cache_numshardbits") {
     options.table_cache_numshardbits = static_cast<int>(value);
   } else if (key == "wal_ttl_seconds") {
-    options.WAL_ttl_seconds = (uint64_t)value;
+    options.WAL_ttl_seconds = static_cast<uint64_t>(value);
   } else if (key == "wal_size_limit_mb") {
-    options.WAL_size_limit_MB = (uint64_t)value;
+    options.WAL_size_limit_MB = static_cast<uint64_t>(value);
   } else if (key == "manifest_preallocation_size") {
     options.manifest_preallocation_size = static_cast<size_t>(value);
   } else if (key == "allow_mmap_reads") {
@@ -1137,13 +1140,13 @@ Status rocksdbOptionsSet(
   } else if (key == "use_adaptive_mutex") {
     options.use_adaptive_mutex = static_cast<bool>(value);
   } else if (key == "bytes_per_sync") {
-    options.bytes_per_sync = (uint64_t)value;
+    options.bytes_per_sync = static_cast<uint64_t>(value);
   } else if (key == "wal_bytes_per_sync") {
-    options.wal_bytes_per_sync = (uint64_t)value;
+    options.wal_bytes_per_sync = static_cast<uint64_t>(value);
   } else if (key == "enable_thread_tracking") {
     options.enable_thread_tracking = static_cast<bool>(value);
   } else if (key == "delayed_write_rate") {
-    options.delayed_write_rate = (uint64_t)value;
+    options.delayed_write_rate = static_cast<uint64_t>(value);
   } else if (key == "enable_pipelined_write") {
     options.enable_pipelined_write = static_cast<bool>(value);
   } else if (key == "allow_concurrent_memtable_write") {
@@ -1151,9 +1154,9 @@ Status rocksdbOptionsSet(
   } else if (key == "enable_write_thread_adaptive_yield") {
     options.enable_write_thread_adaptive_yield = static_cast<bool>(value);
   } else if (key == "write_thread_max_yield_usec") {
-    options.write_thread_max_yield_usec = (uint64_t)value;
+    options.write_thread_max_yield_usec = static_cast<uint64_t>(value);
   } else if (key == "write_thread_slow_yield_usec") {
-    options.write_thread_slow_yield_usec = (uint64_t)value;
+    options.write_thread_slow_yield_usec = static_cast<uint64_t>(value);
   } else if (key == "skip_stats_update_on_db_open") {
     options.skip_stats_update_on_db_open = static_cast<bool>(value);
   } else if (key == "allow_2pc") {
@@ -1259,7 +1262,7 @@ Status rocksdbTableOptionsSet(
   } else if (key == "index_block_restart_interval") {
     options.index_block_restart_interval = static_cast<int>(value);
   } else if (key == "metadata_block_size") {
-    options.metadata_block_size = (uint64_t)value;
+    options.metadata_block_size = static_cast<uint64_t>(value);
   } else if (key == "partition_filters") {
     options.partition_filters = static_cast<bool>(value);
   } else if (key == "use_delta_encoding") {
@@ -1372,7 +1375,7 @@ rocksdb::Options RocksKVStore::options(const std::string cf) {
   options.statistics = _stats;
   options.create_if_missing = true;
 
-  options.max_total_wal_size = uint64_t(4294967296);  // 4GB
+  options.max_total_wal_size = static_cast<uint64_t>(4294967296);  // 4GB
 
   if (_cfg->rocksWALDir != "") {
     options.wal_dir = _cfg->rocksWALDir + "/" + dbId() + "/";
@@ -2510,7 +2513,7 @@ Expected<BackupInfo> RocksKVStore::backup(const std::string& dir,
   }
   result.setFileList(flist);
   result.setEndTimeSec(sinceEpoch());
-  result.setBackupMode((uint32_t)mode);
+  result.setBackupMode(static_cast<uint32_t>(mode));
   result.setBinlogVersion(binlogVersion);
   auto saveret = saveBackupMeta(dir, &result);
   if (!saveret.ok()) {
@@ -2536,7 +2539,7 @@ Expected<std::string> RocksKVStore::saveBackupMeta(const std::string& dir,
   writer.Key("useTimeSec");
   writer.Uint64(backup->getEndTimeSec() - backup->getStartTimeSec());
   writer.Key("binlogVersion");
-  writer.Uint64((uint64_t)backup->getBinlogVersion());
+  writer.Uint64(static_cast<uint64_t>(backup->getBinlogVersion()));
   writer.EndObject();
   std::string data = sb.GetString();
 
@@ -2625,9 +2628,9 @@ Expected<std::string> RocksKVStore::restoreBackup(const std::string& dir) {
   }
 
   uint32_t mode = backup_meta.value().getBackupMode();
-  if (mode == (uint32_t)KVStore::BackupMode::BACKUP_CKPT) {
+  if (mode == static_cast<uint32_t>(KVStore::BackupMode::BACKUP_CKPT)) {
     return copyCkpt(dir);
-  } else if (mode == (uint32_t)KVStore::BackupMode::BACKUP_COPY) {
+  } else if (mode == static_cast<uint32_t>(KVStore::BackupMode::BACKUP_COPY)) {
     return loadCopy(dir);
   }
   LOG(ERROR) << "restoreBackup mode failed:" << dir << " mode:" << mode;
@@ -3272,8 +3275,7 @@ Status RocksKVStore::setOptionDynamic(const std::string& option,
     "rocks.periodic_compaction_seconds",
     "rocks.level0_file_num_compaction_trigger",
     "rocks.level0_slowdown_writes_trigger",
-    "rocks.level0_stop_writes_trigger"
-  };
+    "rocks.level0_stop_writes_trigger"};
   // option, example: "rocks.binlogcf.enable_blob_files"
   // new_option, example: "rocks.enable_blob_files"
   // short_option, example: "enable_blob_files"
@@ -3348,11 +3350,7 @@ const rocksdb::Snapshot* RocksKVStore::getSnapshot() {
 }
 
 Status RocksKVStore::setCompactOnDeletionCollectorFactory(
-  const std::string& option, const std::string& value) {
-  if (option.substr(0, 25) != "rocks.compaction_deletes_") {
-    return {ErrorCodes::ERR_INTERNAL, option + " is not rocksdb option"};
-  }
-
+  const std::string& option, std::shared_ptr<tendisplus::ServerParams> cfg) {
 #if ROCKSDB_MAJOR > 6 || (ROCKSDB_MAJOR == 6 && ROCKSDB_MINOR > 11)
   auto table_properties_collector_factories =
     getBaseDB()->GetOptions().table_properties_collector_factories;
@@ -3363,35 +3361,13 @@ Status RocksKVStore::setCompactOnDeletionCollectorFactory(
       auto compactOnDel =
         static_cast<rocksdb::CompactOnDeletionCollectorFactory*>(factory.get());
       if (table_factory_option == "window") {
-        auto ed = tendisplus::stoul(value);
-        if (!ed.ok()) {
-          errinfo = "invalid CompactOnDeletionCollector window value:" + value +
-            " " + ed.status().toString();
-          return {ErrorCodes::ERR_PARSEOPT, errinfo};
-        }
-
-        compactOnDel->SetWindowSize(ed.value());
+        compactOnDel->SetWindowSize(cfg->rocksCompactOnDeletionWindow);
         return {ErrorCodes::ERR_OK, ""};
       } else if (table_factory_option == "trigger") {
-        auto ed = tendisplus::stoul(value);
-        if (!ed.ok()) {
-          errinfo =
-            "invalid CompactOnDeletionCollector trigger value:" + value + " " +
-            ed.status().toString();
-          return {ErrorCodes::ERR_PARSEOPT, errinfo};
-        }
-
-        compactOnDel->SetDeletionTrigger(ed.value());
+        compactOnDel->SetDeletionTrigger(cfg->rocksCompactOnDeletionTrigger);
         return {ErrorCodes::ERR_OK, ""};
       } else if (table_factory_option == "ratio") {
-        auto ed = tendisplus::stod(value);
-        if (!ed.ok()) {
-          errinfo = "invalid CompactOnDeletionCollector ratio value:" + value +
-            " " + ed.status().toString();
-          return {ErrorCodes::ERR_PARSEOPT, errinfo};
-        }
-
-        compactOnDel->SetDeletionRatio(ed.value());
+        compactOnDel->SetDeletionRatio(cfg->rocksCompactOnDeletionRatio);
         return {ErrorCodes::ERR_OK, ""};
       } else {
         return {ErrorCodes::ERR_INTERNAL,

--- a/src/tendisplus/storage/rocks/rocks_kvstore.h
+++ b/src/tendisplus/storage/rocks/rocks_kvstore.h
@@ -414,7 +414,8 @@ class RocksKVStore : public KVStore {
   Status setOptionDynamic(const std::string& option,
                           const std::string& value) override;
   Status setCompactOnDeletionCollectorFactory(
-    const std::string& option, const std::string& value) override;
+    const std::string& option,
+    std::shared_ptr<tendisplus::ServerParams> cfg) override;
   int64_t getOption(const std::string& option) override;
   const rocksdb::Snapshot* getSnapshot();
   rocksdb::Iterator* newIterator(const rocksdb::ReadOptions& readOptions,


### PR DESCRIPTION
##描述

#310 
修复配置文件里面配置rocks.max_open_files，rocks.max_background_jobs，不能生效

调整了setVar的逻辑，原来对某些参数进行了特殊处理，现在在server_entry将这些参数的特殊处理传入onupdate函数对象
具体有rocks.latency-limit 和 rocks.compaction_deletes_开头的三个参数，共四个

std::function<void()> onupdate 变成std::function<Status()>，可以返回状态，并调整了与之相关的代码

同时也处理了config set完后config get 不到rocks.latency-limit的问题

## 仍然存在的问题

如果rocksdb的参数未在配置文件中配置或者未执行过config set，则config get不能获取。