### PR TITLE
Fix the ldb_tendis core dump issue when profiling is enabled

### DIFF
--- a/src/tendisplus/tools/CMakeLists.txt
+++ b/src/tendisplus/tools/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_executable(ldb_tendis ldb_tendis.cpp)
-target_link_libraries(ldb_tendis record rocksdb "-static -static-libgcc -static-libstdc++ -Wl,--no-as-needed -Wl,--whole-archive -ldl -Wl,--no-whole-archive -pthread -march=native")
+target_link_libraries(ldb_tendis record rocksdb "-static-libgcc -static-libstdc++ -Wl,--no-as-needed -Wl,--whole-archive -ldl -Wl,--no-whole-archive -pthread -march=native")


### PR DESCRIPTION
## Description
修复ldb_tendis在开启profiling时core dump的问题

## Motivation and Context
ldb_tendis在开启profiling时会产生core dump的问题，通过修改编译选项修复了该问题