### PR TITLE
 [bug] support master transfer to slave when failover

### DIFF
--- a/src/tendisplus/cluster/cluster_manager.cpp
+++ b/src/tendisplus/cluster/cluster_manager.cpp
@@ -1011,6 +1011,12 @@ void ClusterState::clusterUpdateSlotsConfigWith(
   CNodePtr newmaster = nullptr;
   uint32_t dirty_slots_count = 0;
 
+  /* We should detect if sender is new master of our shard.
+   * We will know it if all our slots were migrated to sender, and sender
+   * has no slots except ours */
+  int sender_slots = 0;
+  int migrated_our_slots = 0;
+
   /* Here we set curmaster to this node or the node this node
    * replicates to if it's a slave. In the for loop we are
    * interested to check if slots are taken away from curmaster. */
@@ -1028,6 +1034,8 @@ void ClusterState::clusterUpdateSlotsConfigWith(
     }
     for (size_t j = 0; j < CLUSTER_SLOTS; j++) {
       if (slots.test(j)) {
+        sender_slots++;
+
         if (_allSlots[j] == sender)
           continue;
 
@@ -1044,6 +1052,7 @@ void ClusterState::clusterUpdateSlotsConfigWith(
           }
           if (_allSlots[j] == curmaster) {
             newmaster = sender;
+            migrated_our_slots++;
           }
           clusterDelSlotNoLock(j);
           clusterAddSlotNoLock(sender, j);
@@ -1069,7 +1078,9 @@ void ClusterState::clusterUpdateSlotsConfigWith(
    *    master.
    * 2) We are a slave and our master is left without slots. We need
    *    to replicate to the new slots owner. */
-  if (needReconfigure && _server->getParams()->slaveReconfEnabled) {
+  if (needReconfigure &&
+      (_server->getParams()->clusterAllowReplicaMigration ||
+       sender_slots == migrated_our_slots)) {
     serverLog(LL_WARNING,
               "Configuration change detected "
               "Reconfiguring myself as a replica of %.40s",

--- a/src/tendisplus/server/server_params.cpp
+++ b/src/tendisplus/server/server_params.cpp
@@ -541,7 +541,7 @@ ServerParams::ServerParams() {
   REGISTER_VARS_DIFF_NAME_DYNAMIC("aof-psync-num", aofPsyncNum);
   REGISTER_VARS_DIFF_NAME_DYNAMIC("fullPsync-notice-enabled",
                                   fullPsyncNoticeEnable);
-  REGISTER_VARS_DIFF_NAME_DYNAMIC("slave-reconf-enabled", slaveReconfEnabled);
+  REGISTER_VARS_NOUSE("slave-reconf-enabled");
   REGISTER_VARS_DIFF_NAME_DYNAMIC("slave-migrate-enabled",
                                   slaveMigarateEnabled);
   REGISTER_VARS_NOUSE("migrate-gc-enabled");

--- a/src/tendisplus/server/server_params.h
+++ b/src/tendisplus/server/server_params.h
@@ -591,7 +591,6 @@ class ServerParams {
 
   bool clusterEnabled = false;
   bool domainEnabled = false;
-  bool slaveReconfEnabled = true;
   bool slaveMigarateEnabled = false;
   bool clusterAllowReplicaMigration = false;
   bool aofEnabled = false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
 
## 背景

在缩容场景下，如果一个master节点的全部slot迁移出去，一般场景下是希望下架这个节点，而不是让这个master节点再转移到其他节点作为从节点。
这里的难点在于，clusterUpdateSlotsConfigWith()函数中的相关逻辑，不仅涉及搬迁场景，还涉及到故障转移或人工转移场景。修改时，需要同时考虑这两种场景。

社区的解决方法：
https://github.com/redis/redis/pull/5285
社区是通过添加cluster-allow-replica-migration参数来控制，如果不希望转移，则配置false。
但是这个提交遗留一个问题，就是一个master节点将自己的所有slot迁移到一个空的目标节点，这种情况下，即使配置为false，也会迁移到目标节点下作为从节点。不过这种使用场景并不多，因为在扩容的场景下，自己还会保留一部分slot，在缩容的情况下，目标节点不为空。

这个pr参考社区的上述方法。所以废弃之前的slave-reconf-enabled参数。



