### PR TITLE
 support master transfer to slave when failover

### DIFF
--- a/src/tendisplus/cluster/cluster_manager.cpp
+++ b/src/tendisplus/cluster/cluster_manager.cpp
@@ -1002,6 +1002,12 @@ void ClusterState::clusterUpdateSlotsConfigWith(
   CNodePtr newmaster = nullptr;
   uint32_t dirty_slots_count = 0;
 
+  /* We should detect if sender is new master of our shard.
+   * We will know it if all our slots were migrated to sender, and sender
+   * has no slots except ours */
+  int sender_slots = 0;
+  int migrated_our_slots = 0;
+
   /* Here we set curmaster to this node or the node this node
    * replicates to if it's a slave. In the for loop we are
    * interested to check if slots are taken away from curmaster. */
@@ -1019,6 +1025,8 @@ void ClusterState::clusterUpdateSlotsConfigWith(
     }
     for (size_t j = 0; j < CLUSTER_SLOTS; j++) {
       if (slots.test(j)) {
+        sender_slots++;
+
         if (_allSlots[j] == sender)
           continue;
 
@@ -1035,6 +1043,7 @@ void ClusterState::clusterUpdateSlotsConfigWith(
           }
           if (_allSlots[j] == curmaster) {
             newmaster = sender;
+            migrated_our_slots++;
           }
           clusterDelSlotNoLock(j);
           clusterAddSlotNoLock(sender, j);
@@ -1060,7 +1069,9 @@ void ClusterState::clusterUpdateSlotsConfigWith(
    *    master.
    * 2) We are a slave and our master is left without slots. We need
    *    to replicate to the new slots owner. */
-  if (needReconfigure && _server->getParams()->slaveReconfEnabled) {
+  if (needReconfigure &&
+      (_server->getParams()->clusterAllowReplicaMigration ||
+       sender_slots == migrated_our_slots)) {
     serverLog(LL_WARNING,
               "Configuration change detected "
               "Reconfiguring myself as a replica of %.40s",

--- a/src/tendisplus/server/server_params.cpp
+++ b/src/tendisplus/server/server_params.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <list>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -33,61 +34,63 @@ std::shared_ptr<tendisplus::ServerParams> gParams;
 std::string gRenameCmdList = "";   // NOLINT
 std::string gMappingCmdList = "";  // NOLINT
 
-#define REGISTER_VARS_FULL(                                                   \
-  str, var, checkfun, prefun, minval, maxval, allowDynamicSet)                \
-  if (typeid(var) == typeid(int32_t) || typeid(var) == typeid(uint32_t))      \
-    _mapServerParams.insert(                                                  \
-      make_pair(toLower(str),                                                 \
-                new IntVar(str,                                               \
-                           reinterpret_cast<void*>(&var),                     \
-                           checkfun,                                          \
-                           prefun,                                            \
-                           minval,                                            \
-                           maxval,                                            \
-                           allowDynamicSet)));                                \
-  else if (typeid(var) == typeid(int64_t) || typeid(var) == typeid(uint64_t)) \
-    _mapServerParams.insert(                                                  \
-      make_pair(toLower(str),                                                 \
-                new Int64Var(str,                                             \
-                             reinterpret_cast<void*>(&var),                   \
-                             checkfun,                                        \
-                             prefun,                                          \
-                             minval,                                          \
-                             maxval,                                          \
-                             allowDynamicSet)));                              \
-  else if (typeid(var) == typeid(float))                                      \
-    _mapServerParams.insert(                                                  \
-      make_pair(toLower(str),                                                 \
-                new FloatVar(str,                                             \
-                             reinterpret_cast<void*>(&var),                   \
-                             checkfun,                                        \
-                             prefun,                                          \
-                             allowDynamicSet)));                              \
-  else if (typeid(var) == typeid(double))                                     \
-    _mapServerParams.insert(                                                  \
-      make_pair(toLower(str),                                                 \
-                new DoubleVar(str,                                            \
-                              reinterpret_cast<void*>(&var),                  \
-                              checkfun,                                       \
-                              prefun,                                         \
-                              allowDynamicSet)));                             \
-  else if (typeid(var) == typeid(std::string))                                \
-    _mapServerParams.insert(                                                  \
-      make_pair(toLower(str),                                                 \
-                new StringVar(str,                                            \
-                              reinterpret_cast<void*>(&var),                  \
-                              checkfun,                                       \
-                              prefun,                                         \
-                              allowDynamicSet)));                             \
-  else if (typeid(var) == typeid(bool))                                       \
-    _mapServerParams.insert(                                                  \
-      make_pair(toLower(str),                                                 \
-                new BoolVar(str,                                              \
-                            reinterpret_cast<void*>(&var),                    \
-                            checkfun,                                         \
-                            prefun,                                           \
-                            allowDynamicSet)));                               \
-  else                                                                        \
+#define REGISTER_VARS_FULL(                                    \
+  str, var, checkfun, prefun, minval, maxval, allowDynamicSet) \
+  if (typeid(var) == typeid(int32_t) || /* NOLINT */           \
+      typeid(var) == typeid(uint32_t))  /* NOLINT */           \
+    _mapServerParams.insert(                                   \
+      make_pair(toLower(str),                                  \
+                new IntVar(str,                                \
+                           reinterpret_cast<void*>(&var),      \
+                           checkfun,                           \
+                           prefun,                             \
+                           minval,                             \
+                           maxval,                             \
+                           allowDynamicSet)));                 \
+  else if (typeid(var) == typeid(int64_t) || /* NOLINT */      \
+           typeid(var) == typeid(uint64_t))  /* NOLINT */      \
+    _mapServerParams.insert(                                   \
+      make_pair(toLower(str),                                  \
+                new Int64Var(str,                              \
+                             reinterpret_cast<void*>(&var),    \
+                             checkfun,                         \
+                             prefun,                           \
+                             minval,                           \
+                             maxval,                           \
+                             allowDynamicSet)));               \
+  else if (typeid(var) == typeid(float))                       \
+    _mapServerParams.insert(                                   \
+      make_pair(toLower(str),                                  \
+                new FloatVar(str,                              \
+                             reinterpret_cast<void*>(&var),    \
+                             checkfun,                         \
+                             prefun,                           \
+                             allowDynamicSet)));               \
+  else if (typeid(var) == typeid(double))                      \
+    _mapServerParams.insert(                                   \
+      make_pair(toLower(str),                                  \
+                new DoubleVar(str,                             \
+                              reinterpret_cast<void*>(&var),   \
+                              checkfun,                        \
+                              prefun,                          \
+                              allowDynamicSet)));              \
+  else if (typeid(var) == typeid(std::string))                 \
+    _mapServerParams.insert(                                   \
+      make_pair(toLower(str),                                  \
+                new StringVar(str,                             \
+                              reinterpret_cast<void*>(&var),   \
+                              checkfun,                        \
+                              prefun,                          \
+                              allowDynamicSet)));              \
+  else if (typeid(var) == typeid(bool))                        \
+    _mapServerParams.insert(                                   \
+      make_pair(toLower(str),                                  \
+                new BoolVar(str,                               \
+                            reinterpret_cast<void*>(&var),     \
+                            checkfun,                          \
+                            prefun,                            \
+                            allowDynamicSet)));                \
+  else                                                         \
     INVARIANT(0);  // NOTE(takenliu): if other type is needed, change here.
 
 static const char* NO_USE_VALUE = "NO_USE";
@@ -541,7 +544,7 @@ ServerParams::ServerParams() {
   REGISTER_VARS_DIFF_NAME_DYNAMIC("aof-psync-num", aofPsyncNum);
   REGISTER_VARS_DIFF_NAME_DYNAMIC("fullPsync-notice-enabled",
                                   fullPsyncNoticeEnable);
-  REGISTER_VARS_DIFF_NAME_DYNAMIC("slave-reconf-enabled", slaveReconfEnabled);
+  REGISTER_VARS_NOUSE("slave-reconf-enabled");
   REGISTER_VARS_DIFF_NAME_DYNAMIC("slave-migrate-enabled",
                                   slaveMigarateEnabled);
   REGISTER_VARS_NOUSE("migrate-gc-enabled");

--- a/src/tendisplus/server/server_params.h
+++ b/src/tendisplus/server/server_params.h
@@ -583,7 +583,6 @@ class ServerParams {
 
   bool clusterEnabled = false;
   bool domainEnabled = false;
-  bool slaveReconfEnabled = true;
   bool slaveMigarateEnabled = false;
   bool clusterAllowReplicaMigration = false;
   bool aofEnabled = false;


### PR DESCRIPTION
在缩容场景下，如果一个master节点的全部slot迁移出去，一般场景下是希望下架这个节点，而不是让这个master节点再转移到其他节点作为从节点。
这里的难点在于，clusterUpdateSlotsConfigWith()函数中的相关逻辑，不仅涉及搬迁场景，还涉及到故障转移或人工转移场景。修改时，需要同时考虑这两种场景。

社区的解决方法：
https://github.com/redis/redis/pull/5285
社区是通过添加cluster-allow-replica-migration参数来控制，如果不希望转移，则配置false。
但是这个提交遗留一个问题，就是一个master节点将自己的所有slot迁移到一个空的目标节点，这种情况下，即使配置为false，也会迁移到目标节点下作为从节点。不过这种使用场景并不多，因为在扩容的场景下，自己还会保留一部分slot，在缩容的情况下，目标节点不为空。

这个pr参考社区的上述方法。所以废弃之前的slave-reconf-enabled参数。