### PR TITLE
remove warning of nouse config

### DIFF
--- a/src/tendisplus/cluster/cluster_test.cpp
+++ b/src/tendisplus/cluster/cluster_test.cpp
@@ -2377,8 +2377,13 @@ TEST(Cluster, migrateNotAutoReconfSlave) {
     std::this_thread::sleep_for(std::chrono::seconds(5));
   });
   // 2 master & 2 slave
-  auto servers = makeCluster(
-    startPort, nodeNum, 10, true, false, {}, {{"slave-reconf-enabled", "no"}});
+  auto servers = makeCluster(startPort,
+                             nodeNum,
+                             10,
+                             true,
+                             false,
+                             {},
+                             {{"cluster-allow-replica-migration", "no"}});
   SlotsBitmap sbm;
   for (int i = 0; i <= 8192; i++) {
     sbm.set(i);

--- a/src/tendisplus/server/server_params.cpp
+++ b/src/tendisplus/server/server_params.cpp
@@ -192,7 +192,7 @@ std::string removeQuotesAndToLower(const std::string& v) {
 }
 
 void NoUseWarning(const std::string& name) {
-  LOG(INFO) << name << "is not supported anymore" << std::endl;
+  std::cout << name << "is not supported anymore" << std::endl;
 }
 
 Status rewriteConfigState::rewriteConfigReadOldFile(

--- a/src/tendisplus/server/server_params.h
+++ b/src/tendisplus/server/server_params.h
@@ -356,7 +356,7 @@ class NoUseVar : public BaseVar {
            checkfunptr ptr,
            preProcess preFun,
            bool allowDynamicSet)
-    : BaseVar(name, v, ptr, preFun, allowDynamicSet), _setFlag(false) {}
+    : BaseVar(name, v, ptr, preFun, allowDynamicSet) {}
   virtual std::string show() const {
     return " not supported anymore";
   }
@@ -364,16 +364,14 @@ class NoUseVar : public BaseVar {
     return "no";
   }
   virtual bool need_show() const {
-    return _setFlag;
+    return false;  // don't show this var
   }
 
  private:
   TSAN_SUPPRESSION Status set(const std::string& val, bool startup) {
-    _setFlag = true;
     NoUseWarning(name);
     return {ErrorCodes::ERR_OK, ""};
   }
-  bool _setFlag;
 };
 
 class rewriteConfigState {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
在配置文件中设置了nouse的配置（例如slave-reconf-enabled），会在输出config信息时输出这个参数，并且会输出warning，现在把这两个输出去除