### PR TITLE
support "cluster setslot gc"

### DIFF
--- a/src/tendisplus/cluster/gc_manager.cpp
+++ b/src/tendisplus/cluster/gc_manager.cpp
@@ -4,7 +4,10 @@
 
 #include "tendisplus/cluster/gc_manager.h"
 
+#include <memory>
 #include <thread>
+#include <utility>
+#include <vector>
 
 #include "tendisplus/commands/command.h"
 
@@ -35,11 +38,18 @@ void GCManager::controlRoutine() {
   // 4. do actual deleteRange job.
   while (_isRunning.load(std::memory_order_relaxed)) {
     if (_svr->getMigrateManager()->existMigrateTask()) {
+      std::lock_guard<std::mutex> lk(_mutex);
       _waitTimeAfterMigrate = _svr->getParams()->waitTimeIfExistsMigrateTask;
-    } else if (_waitTimeAfterMigrate > 0) {
-      _waitTimeAfterMigrate--;
     } else {
-      gcSchedule();
+      {
+        std::lock_guard<std::mutex> lk(_mutex);
+        if (_waitTimeAfterMigrate > 0) {
+          _waitTimeAfterMigrate--;
+        }
+      }
+      if (_waitTimeAfterMigrate == 0) {
+        gcSchedule();
+      }
     }
 
     std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/src/tendisplus/cluster/gc_manager.h
+++ b/src/tendisplus/cluster/gc_manager.h
@@ -51,6 +51,10 @@ class GCManager {
                       bool dumpIfError = true);
 
   Status delGarbage();
+  void gcNow() {
+    std::lock_guard<std::mutex> lk(_mutex);
+    _waitTimeAfterMigrate = 0;
+  }
 
  private:
   void controlRoutine();

--- a/src/tendisplus/commands/cluster.cpp
+++ b/src/tendisplus/commands/cluster.cpp
@@ -136,7 +136,7 @@ class ClusterCommand : public Command {
             Expected<int64_t> exptSlot = ::tendisplus::stoll(vs);
             RET_IF_ERR_EXPECTED(exptSlot);
 
-            int32_t slot = (int32_t)exptSlot.value();
+            int32_t slot = static_cast<int32_t>(exptSlot.value());
 
             if (slot > CLUSTER_SLOTS - 1 || slot < 0) {
               LOG(ERROR) << "slot" << slot
@@ -164,6 +164,7 @@ class ClusterCommand : public Command {
           return {ErrorCodes::ERR_CLUSTER, "Invalid migrate info"};
         }
       } else if (arg2 == "clean" && argSize == 3) {
+        LOG(INFO) << sess->getCmdStr();
         if (migrateMgr->existMigrateTask()) {
           return {ErrorCodes::ERR_CLUSTER, "can not clean when migrating"};
         }
@@ -216,6 +217,7 @@ class ClusterCommand : public Command {
         }
         return taskInfo.value();
       } else if (arg2 == "stop" && argSize > 3) {
+        LOG(INFO) << sess->getCmdStr();
         for (size_t i = 3; i < args.size(); i++) {
           LOG(INFO) << "stopping tasks, the parent taskid is:" << args[i];
           auto s = migrateMgr->stopTasks(args[i]);
@@ -238,15 +240,18 @@ class ClusterCommand : public Command {
         return Command::fmtOK();
 #endif
       } else if (arg2 == "stopall" && argSize == 3) {
+        LOG(INFO) << sess->getCmdStr();
         /* NOTE(wayenchen) stop all migrate tasks (save message of stop tasks),
          * work on both srcNode and dstNode */
         migrateMgr->stopAllTasks();
         return Command::fmtOK();
       } else if (arg2 == "cleanall" && argSize == 3) {
+        LOG(INFO) << sess->getCmdStr();
         /* NOTE(wayenchen) clean all migrate tasks, no save message*/
         migrateMgr->stopAllTasks(false);
         return Command::fmtOK();
       } else if (arg2 == "restartall" && argSize == 3) {
+        LOG(INFO) << sess->getCmdStr();
         /* NOTE(wayenchen) it is work on dstNode command */
         std::map<std::string, SlotsBitmap> remainSlotsMap =
           migrateMgr->getStopMap();
@@ -261,7 +266,8 @@ class ClusterCommand : public Command {
           auto taskMap = (*it).second;
           auto srcNode = clusterState->clusterLookupNode(nodeId);
           if (srcNode == nullptr) {
-            return {ErrorCodes::ERR_CLUSTER, "import node not find"};
+            LOG(ERROR) << "node " << nodeId << " not found";
+            return {ErrorCodes::ERR_CLUSTER, "import node not find:" + nodeId};
           }
           auto exptTaskid = startAllSlotsTasks(
             taskMap, svr, nodeId, clusterState, srcNode, myself, true);
@@ -275,6 +281,10 @@ class ClusterCommand : public Command {
           migrateMgr->removeRestartSlots(nodeId, (*it).second);
         }
 
+        return Command::fmtOK();
+      } else if (arg2 == "gc" && argSize == 3) {
+        LOG(INFO) << sess->getCmdStr();
+        gcMgr->gcNow();
         return Command::fmtOK();
       }
     } else if (arg1 == "meet" && (argSize == 4 || argSize == 5)) {
@@ -445,7 +455,7 @@ class ClusterCommand : public Command {
         return {ErrorCodes::ERR_CLUSTER, "keyslot invalid!"};
       }
       uint32_t hash =
-        uint32_t(redis_port::keyHashSlot(key.c_str(), key.size()));
+        static_cast<uint32_t>(redis_port::keyHashSlot(key.c_str(), key.size()));
       return Command::fmtBulk(std::to_string(hash));
     } else if (arg1 == "info" && argSize == 2) {
       std::string clusterInfo = clusterState->clusterGenStateDescription();
@@ -769,6 +779,8 @@ class ClusterCommand : public Command {
     auto ip = srcNode->getNodeIp();
     auto port = srcNode->getPort();
 
+    LOG(INFO) << "startImportingTasks srcIp:" << ip << " srcPort:" << port
+              << " slots:" << bitsetStrEncode(slotsMap);
     std::shared_ptr<BlockingTcpClient> client = createClient(ip, port, svr);
 
     if (client == nullptr) {

--- a/src/tendisplus/network/blocking_tcp_client.cpp
+++ b/src/tendisplus/network/blocking_tcp_client.cpp
@@ -148,7 +148,7 @@ Status BlockingTcpClient::tryWaitConnect() {
     _socket.set_option(asio::socket_base::keep_alive(true));
     return {ErrorCodes::ERR_OK, ""};
   } else {
-    if (msSinceEpoch() - _ctime > (uint64_t)_timeout.count()) {
+    if (msSinceEpoch() - _ctime > static_cast<uint64_t>(_timeout.count())) {
       return {ErrorCodes::ERR_TIMEOUT, "conn timeout"};
     }
 
@@ -212,7 +212,8 @@ Expected<std::string> BlockingTcpClient::realRead(
     std::unique_lock<std::mutex> lk(_mutex);
     if (!_cv.wait_for(lk, timeout, [this] { return _notified; })) {
       closeSocket();
-      return {ErrorCodes::ERR_TIMEOUT, "read timeout" + std::to_string(remain)};
+      return {ErrorCodes::ERR_TIMEOUT,
+              "read timeout,remain:" + std::to_string(remain)};
     } else if (_ec) {
       closeSocket();
       return {ErrorCodes::ERR_NETWORK, _ec.message()};


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

#370
1.支持“cluster setslot gc”，可以立即清理脏数据，而不需要等待wait-time-if-exists-migrate-task（默认10分钟）之后再清理。
如果重试失败的任务时报错：”(error) ERR:18,msg:slot in deleting task8001“，可以调用该命令，方便立即重试。
2.添加一些日志。

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Code follows the code style of this project.
- [ ] Change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.