### PR TITLE
fix bug of "cluster setslot restart/restartall" maybe return failed: "-ERR check"

### DIFF
--- a/src/tendisplus/cluster/migrate_manager.cpp
+++ b/src/tendisplus/cluster/migrate_manager.cpp
@@ -188,7 +188,7 @@ Status MigrateManager::stopSrcNode(const std::string& taskid,
                                    const std::string& srcIp,
                                    uint64_t port) {
   LOG(INFO) << "send stop command to srcNode:" << srcIp << ":" << port
-            << "on taskid:" << taskid;
+            << " on taskid:" << taskid;
   std::string srcHost = srcIp;
   auto srcPort = port;
   std::shared_ptr<BlockingTcpClient> client =
@@ -319,7 +319,6 @@ Status MigrateManager::stopAllTasks(bool saveSlots) {
     auto s = stopSrcNode(iter->first, node->getNodeIp(), node->getPort());
     if (!s.ok()) {
       LOG(ERROR) << "stop srcNode task fail:" << s.toString();
-      return s;
     }
   }
 
@@ -1125,7 +1124,6 @@ bool MigrateManager::receiverSchedule(const SCLOCK::time_point& now) {
               _failImportSlots.reset(i);
             }
           } else {
-            LOG(INFO) << "_migrateReceiveTask ERR, erase it, slots" << i;
             _failImportSlots.set(i);
           }
           _importNodes.erase(i);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#378 

重试之前stop的搬迁任务，可能会报错：
```
> cluster setslot stopall
OK

> cluster setslot restartall
(error) ERR:7,msg:json contain err:-ERR check

> cluster setslot restart 50cb51bea68e4aa94f2ebde021f175556b5ef906 {10922..12013}
(error) ERR:7,msg:json contain err:-ERR check
```

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Code follows the code style of this project.
- [ ] Change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.