### PR TITLE
The output format of stat.go is precise to one more decimal place

### DIFF
--- a/code-format.sh
+++ b/code-format.sh
@@ -39,6 +39,9 @@ do
         fi
     fi
     if [[ $file =~ \.go$ ]]; then
+        # print diff
         gofmt -d $file
+        # rewrite the file
+        gofmt -w $file
     fi
 done

--- a/src/tendisplus/perftools/stat.go
+++ b/src/tendisplus/perftools/stat.go
@@ -102,16 +102,18 @@ func normInt(val uint64, withB bool) string {
 		}
 		return fmt.Sprintf("%d", val)
 	}
-	val = val / 1024
-	if val < 1024 {
-		return fmt.Sprintf("%dK", val)
+
+	fVal := float64(val)
+	fVal /= 1024.0
+	if fVal < 1024 {
+		return fmt.Sprintf("%.1fK", fVal)
 	}
-	val = val / 1024
-	if val < 1024 {
-		return fmt.Sprintf("%dM", val)
+	fVal /= 1024.0
+	if fVal < 1024 {
+		return fmt.Sprintf("%.1fM", fVal)
 	}
-	val = val / 1024
-	return fmt.Sprintf("%dG", val)
+	fVal /= 1024.0
+	return fmt.Sprintf("%.1fG", fVal)
 }
 
 func main() {
@@ -121,12 +123,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("dial host %s failed:%v", host, err)
 	}
-    if *passwd != "" {
-        if v, err := client.Cmd("AUTH", *passwd).Str(); err != nil || v != "OK" {
-            log.Fatalf("auth failed.")
-        }
-    }
-
+	if *passwd != "" {
+		if v, err := client.Cmd("AUTH", *passwd).Str(); err != nil || v != "OK" {
+			log.Fatalf("auth failed.")
+		}
+	}
 
 	var oldInfo *DebugInfo = nil
 	info := &DebugInfo{}
@@ -143,13 +144,13 @@ func main() {
 	for {
 		v, err := client.Cmd("tendisstat").Str()
 		if err != nil {
-    		s := fmt.Sprintf("send debug cmd failed:%v", err)
-	    	fmt.Fprintln(w, s)
+			s := fmt.Sprintf("send debug cmd failed:%v", err)
+			fmt.Fprintln(w, s)
 			log.Fatalf("send debug cmd failed:%v", err)
 		}
 		if err := json.Unmarshal([]byte(v), &info); err != nil {
-    		s := fmt.Sprintf("unmarshal debug info failed:%v", err)
-	    	fmt.Fprintln(w, s)
+			s := fmt.Sprintf("unmarshal debug info failed:%v", err)
+			fmt.Fprintln(w, s)
 			log.Fatalf("unmarshal debug info failed:%v", err)
 		}
 		if oldInfo == nil {
@@ -204,7 +205,7 @@ func main() {
 			normInt(qtps, false),
 			inqueue,
 			maxLag,
-            info.Request.Processed)
+			info.Request.Processed)
 		fmt.Fprintln(w, s)
 		w.Flush()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#390

./stat -host x.x.x.x -port 51002 -password xxxx
<img width="676" height="171" alt="image" src="https://github.com/user-attachments/assets/1f85a709-cce7-4103-9255-ad9167ef33ff" />

之前输出格式为整数，精度太低了，特别是qtps字段，改为增加一位小数。

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Code follows the code style of this project.
- [ ] Change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.