### PR TITLE
Fix(Security) :  Redis Lua security vulnerabilities (CVE-2020-14147 ,CVE-2024-31449, CVE-2025-29844)

### DIFF
--- a/src/thirdparty/lua/src/lparser.c
+++ b/src/thirdparty/lua/src/lparser.c
@@ -384,13 +384,17 @@ Proto *luaY_parser (lua_State *L, ZIO *z, Mbuffer *buff, const char *name) {
   struct LexState lexstate;
   struct FuncState funcstate;
   lexstate.buff = buff;
-  luaX_setinput(L, &lexstate, z, luaS_new(L, name));
+  TString *tname = luaS_new(L, name);
+  setsvalue2s(L, L->top, tname);
+  incr_top(L);
+  luaX_setinput(L, &lexstate, z, tname);
   open_func(&lexstate, &funcstate);
   funcstate.f->is_vararg = VARARG_ISVARARG;  /* main func. is always vararg */
   luaX_next(&lexstate);  /* read first token */
   chunk(&lexstate);
   check(&lexstate, TK_EOS);
   close_func(&lexstate);
+  --L->top;
   lua_assert(funcstate.prev == NULL);
   lua_assert(funcstate.f->nups == 0);
   lua_assert(lexstate.fs == NULL);

--- a/src/thirdparty/lua/src/lua_bit.c
+++ b/src/thirdparty/lua/src/lua_bit.c
@@ -131,6 +131,7 @@ static int bit_tohex(lua_State *L)
   const char *hexdigits = "0123456789abcdef";
   char buf[8];
   int i;
+  if (n == INT32_MIN) n = INT32_MIN+1;
   if (n < 0) { n = -n; hexdigits = "0123456789ABCDEF"; }
   if (n > 8) n = 8;
   for (i = (int)n; --i >= 0; ) { buf[i] = hexdigits[b & 15]; b >>= 4; }

--- a/src/thirdparty/lua/src/lua_struct.c
+++ b/src/thirdparty/lua/src/lua_struct.c
@@ -96,7 +96,7 @@ static int getnum (lua_State *L, const char **fmt, int df) {
     int a = 0;
     do {
       if (a > (INT_MAX / 10) || a * 10 > (INT_MAX - (**fmt - '0')))
-      luaL_error(L, "integral size overflow");
+        luaL_error(L, "integral size overflow");
       a = a*10 + *((*fmt)++) - '0';
     } while (isdigit(**fmt));
     return a;

--- a/src/thirdparty/lua/src/lua_struct.c
+++ b/src/thirdparty/lua/src/lua_struct.c
@@ -117,7 +117,7 @@ static size_t optsize (lua_State *L, char opt, const char **fmt) {
     case 'f':  return sizeof(float);
     case 'd':  return sizeof(double);
     case 'x': return 1;
-    case 'c': return  getnum(L, fmt, 1);
+    case 'c': return getnum(L, fmt, 1);
     case 'i': case 'I': {
       int sz = getnum(L, fmt, sizeof(int));
       if (sz > MAXINTSIZE)

--- a/src/thirdparty/lua/src/lua_struct.c
+++ b/src/thirdparty/lua/src/lua_struct.c
@@ -89,12 +89,14 @@ typedef struct Header {
 } Header;
 
 
-static int getnum (const char **fmt, int df) {
+static int getnum (lua_State *L, const char **fmt, int df) {
   if (!isdigit(**fmt))  /* no number? */
     return df;  /* return default value */
   else {
     int a = 0;
     do {
+      if (a > (INT_MAX / 10) || a * 10 > (INT_MAX - (**fmt - '0')))
+      luaL_error(L, "integral size overflow");
       a = a*10 + *((*fmt)++) - '0';
     } while (isdigit(**fmt));
     return a;
@@ -115,9 +117,9 @@ static size_t optsize (lua_State *L, char opt, const char **fmt) {
     case 'f':  return sizeof(float);
     case 'd':  return sizeof(double);
     case 'x': return 1;
-    case 'c': return getnum(fmt, 1);
+    case 'c': return  getnum(L, fmt, 1);
     case 'i': case 'I': {
-      int sz = getnum(fmt, sizeof(int));
+      int sz = getnum(L, fmt, sizeof(int));
       if (sz > MAXINTSIZE)
         luaL_error(L, "integral size %d is larger than limit of %d",
                        sz, MAXINTSIZE);
@@ -150,7 +152,7 @@ static void controloptions (lua_State *L, int opt, const char **fmt,
     case '>': h->endian = BIG; return;
     case '<': h->endian = LITTLE; return;
     case '!': {
-      int a = getnum(fmt, MAXALIGN);
+      int a = getnum(L, fmt, MAXALIGN);
       if (!isp2(a))
         luaL_error(L, "alignment %d is not a power of 2", a);
       h->align = a;

--- a/tests/rr_unit/scripting.tcl
+++ b/tests/rr_unit/scripting.tcl
@@ -558,7 +558,6 @@ start_server {tags {"scripting repl"}} {
         #        fail "Expected 1 in x, but value is '[r -1 get x]'"
         #    }
         #}
-
         test {Lua scripts using SELECT are replicated correctly} {
             r eval {
                 redis.call("set","foo1","bar1")
@@ -580,5 +579,10 @@ start_server {tags {"scripting repl"}} {
                 fail "Master-Slave desync after Lua script using SELECT."
             }
         }
+        test {lua bit.tohex bug} {
+            set res [run_script {return bit.tohex(65535, -2147483648)} 0]
+            r ping
+            set res
+        } {0000FFFF}
     }
 }

--- a/tests/rr_unit/scripting.tcl
+++ b/tests/rr_unit/scripting.tcl
@@ -558,6 +558,7 @@ start_server {tags {"scripting repl"}} {
         #        fail "Expected 1 in x, but value is '[r -1 get x]'"
         #    }
         #}
+        
         test {Lua scripts using SELECT are replicated correctly} {
             r eval {
                 redis.call("set","foo1","bar1")
@@ -579,8 +580,9 @@ start_server {tags {"scripting repl"}} {
                 fail "Master-Slave desync after Lua script using SELECT."
             }
         }
-        test {lua bit.tohex bug} {
-            set res [run_script {return bit.tohex(65535, -2147483648)} 0]
+
+        test {lua bit.tohex INT32_MIN} {
+            set res [run_script { return string.upper(bit.tohex(65535, -2147483648)) } 0]
             r ping
             set res
         } {0000FFFF}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

### CVE-2020-14147
Affected component/file: `lua_struct.c`
CVE-2020-14147 was found in Redis, where an integer overflow in lua_struct.c (getnum) could trigger a stack-based buffer overflow when processing large numbers in Lua scripts, allowing DoS or sandbox bypass; fixed in 6.0.3.
According to the [Redis commit](https://github.com/antirez/redis/commit/ef764dde1cca2f25d00686673d1bc89448819571), this vulnerability can lead to DoS attacks.

### CVE-2024-31449
Affected component/file: `lua_bit.c`
CVE-2024-31449 was found in Redis, and the same behavior is reproduced in Dragonfly.
A Lua stack overflow causes a crash.
According to the [Redis security advisory](https://github.com/redis/redis/security/advisories/GHSA-whxg-wx83-85p5), this vulnerability can lead to RCE attacks.

### CVE-2025-29844
Affected component/file: `lparser.c`
Redis versions 6.2.6 and below are vulnerable to remote code execution via a specially crafted Lua script that manipulates the garbage collector to trigger use-after-free.
Fixed in version 8.2.2. Workaround: Use ACL to restrict EVAL and EVALSHA commands.
According to the [Redis security advisory](https://github.com/redis/redis/security/advisories/GHSA-4789-qfc9-5f9q), this vulnerability can lead use-after-free and potentially lead to remote code execution.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is required to address multiple critical vulnerabilities in the Redis Lua subsystem (CVE-2020-14147, CVE-2024-31449, CVE-2025-29844). Exploitation of these issues can lead to denial of service, sandbox escape, use-after-free, or remote code execution when untrusted Lua scripts are allowed to run. Fixing these issues improves the safety of environments that enable Lua scripting and prevents potential compromise of Redis instances.

This PR collects the fixes and hardening measures for the affected files:
- `lua_struct.c` (getnum overflow / CVE-2020-14147)
- `lua_bit.c` (Lua stack overflow / CVE-2024-31449)
- `lparser.c` (GC-induced UAF / CVE-2025-29844)

References:
- Redis commit for CVE-2020-14147: https://github.com/antirez/redis/commit/ef764dde1cca2f25d00686673d1bc89448819571
- Redis advisory for CVE-2024-31449: https://github.com/redis/redis/security/advisories/GHSA-whxg-wx83-85p5
- Redis advisory for CVE-2025-29844: https://github.com/redis/redis/security/advisories/GHSA-4789-qfc9-5f9q

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Code follows the code style of this project.
- [x] Change requires a change to the documentation.
- [x] I have updated the documentation accordingly.