### PR TITLE
fix bug for python redis run info all crash when slave in full sync s…

### DIFF
--- a/src/tendisplus/replication/repl_manager.cpp
+++ b/src/tendisplus/replication/repl_manager.cpp
@@ -1755,7 +1755,7 @@ void ReplManager::getReplInfoDetail(std::stringstream& ss) const {
          ++iter) {
       std::string state = getEnumStr(iter->second->state);
       ss << "rocksdb" << i << "_slave" << j++ << ":";
-      ss << ",ip=" << iter->second->slave_listen_ip;
+      ss << "ip=" << iter->second->slave_listen_ip;
       ss << ",port=" << iter->second->slave_listen_port;
       ss << ",dest_store_id=" << iter->second->storeid;
       ss << ",state=" << state;


### PR DESCRIPTION
…tate

<!--- Provide a general summary of your changes in the Title above -->

## Description
当 存在 slave 在执行全同步时 info all 中的 这种状态的slave多了1个逗号,导致 python redis驱动 解析 info
all 结果时发生错误

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
修复info all的结果输出,去掉无效的逗号.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Code follows the code style of this project.
- [ ] Change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.