### PR TITLE
Fix: dynamic configuration of RocksDB CF parameters now applies to all column families

### DIFF
--- a/.github/actions/cleanup/action.yml
+++ b/.github/actions/cleanup/action.yml
@@ -1,0 +1,40 @@
+name: "cleanup"
+description: "Remove large pre-installed tools to free disk space"
+
+inputs:
+  show-before:
+    description: "Print disk usage before cleanup"
+    required: false
+    default: "false"
+  show-after:
+    description: "Print disk usage after cleanup"
+    required: false
+    default: "true"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Show disk usage before cleanup
+      if: ${{ inputs.show-before == 'true' }}
+      shell: bash
+      run: |
+        echo "=== Disk usage before cleanup ==="
+        df -h
+        sudo du -sh /home/* /usr/* /var/* /opt/* 2>/dev/null | sort -h | tail -n 40
+
+    - name: Clean up pre-installed tools
+      shell: bash
+      run: |
+        set -e
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/hostedtoolcache
+        echo "=== Disk usage after cleanup (raw df) ==="
+        df -h
+
+    - name: Show disk usage after cleanup (detailed)
+      if: ${{ inputs.show-after == 'true' }}
+      shell: bash
+      run: |
+        echo "=== Largest dirs under /usr, /opt, /home ==="
+        sudo du -sh /usr/* /opt/* /home/* 2>/dev/null | sort -h | tail -n 30

--- a/.github/workflows/Tendis-CI.yml
+++ b/.github/workflows/Tendis-CI.yml
@@ -6,6 +6,7 @@ on:
   push:
   # set to a branch that does not exist to disable the workflow
     branches: [notExistBranch]
+     
 jobs:
   cpplint-check:
     name: Lint
@@ -98,6 +99,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
+      - name: cleanup
+        uses: ./.github/actions/cleanup/
       - name: compile
         uses: ./.github/actions/compile/
       - name: Unit Test
@@ -123,6 +126,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
+      - name: cleanup
+        uses: ./.github/actions/cleanup/
       - name: compile
         uses: ./.github/actions/compile/
       - name: Redis Test
@@ -148,6 +153,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
+      - name: cleanup
+        uses: ./.github/actions/cleanup/
       - name: compile
         uses: ./.github/actions/compile/
       - name: Restore Test
@@ -163,6 +170,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
+      - name: cleanup
+        uses: ./.github/actions/cleanup/
       - name: compile
         uses: ./.github/actions/compile/
       - name: Repl Test
@@ -178,6 +187,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
+      - name: cleanup
+        uses: ./.github/actions/cleanup/
       - name: compile
         uses: ./.github/actions/compile/
       - name: Cluster Test
@@ -193,6 +204,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
+      - name: cleanup
+        uses: ./.github/actions/cleanup/
       - name: compile
         uses: ./.github/actions/compile/
       - name: Cluster Test
@@ -204,10 +217,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
         TEST_DIR: build/bin
-    steps:
+    steps:   
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
+      - name: cleanup
+        uses: ./.github/actions/cleanup/
       - name: compile
         uses: ./.github/actions/compile/
       - name: GoTest
@@ -225,6 +240,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
+      - name: cleanup
+        uses: ./.github/actions/cleanup/
       - name: compile
         uses: ./.github/actions/compile/
       - name: GoTest
@@ -232,6 +249,8 @@ jobs:
           cd src/tendisplus/integrate_test
           chmod +x gotest.sh
           ./gotest.sh normaltest-part2
+          rm -rf tmp/ .cache/
+  
   test-gotest-normaltest-part3:
     needs: [cpplint-check]
     name: Test-gotest-normaltest-part3
@@ -242,6 +261,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
+      - name: cleanup
+        uses: ./.github/actions/cleanup/
       - name: compile
         uses: ./.github/actions/compile/
       - name: GoTest
@@ -262,6 +283,8 @@ jobs:
           fetch-depth: 2
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: cleanup
+        uses: ./.github/actions/cleanup/
       - name: compile
         uses: ./.github/actions/compile/
       - name: GoTest

--- a/src/tendisplus/commands/command_test.cpp
+++ b/src/tendisplus/commands/command_test.cpp
@@ -901,7 +901,7 @@ void testLatencyMonitor(std::shared_ptr<ServerEntry> svr) {
     EXPECT_TRUE(expect.ok());
     found = std::regex_search(expect.value(), matches, pattern);
     if (found) {
-      assert(matches.size() > 2);
+      assert(matches.size() >= 2);
       std::string res = matches[1];
       assert(res.size() > 10);
       auto v = res.substr(res.size() - 10, res.size());
@@ -914,7 +914,7 @@ void testLatencyMonitor(std::shared_ptr<ServerEntry> svr) {
   EXPECT_TRUE(expect.ok());
   found = std::regex_search(expect.value(), matches, pattern);
   if (found) {
-    assert(matches.size() > 2);
+    assert(matches.size() >= 2);
     std::string res = matches[1];
     assert(res.size() > 10);
     auto v = res.substr(res.size() - 10, res.size());
@@ -929,7 +929,7 @@ void testLatencyMonitor(std::shared_ptr<ServerEntry> svr) {
   EXPECT_TRUE(expect.ok());
   found = std::regex_search(expect.value(), matches, pattern);
   if (found) {
-    assert(matches.size() > 2);
+    assert(matches.size() >= 2);
     std::string res = matches[1];
     assert(res.size() > 10);
     auto v = res.substr(res.size() - 10, res.size());
@@ -2886,6 +2886,117 @@ TEST(Command, rocksdbOptionsCommand) {
   getGlobalServer()->stop();
   EXPECT_EQ(getGlobalServer().use_count(), 1);
 #endif
+}
+
+void testRocksCFOptionConfig(std::shared_ptr<ServerEntry> svr,
+                             int df_status,
+                             int bl_status) {
+  asio::io_context ioContext;
+  asio::ip::tcp::socket socket(ioContext);
+  NetSession sess(svr, std::move(socket), 1, false, nullptr, nullptr);
+  for (uint32_t i = 0; i < svr->getKVStoreCount(); i++) {
+    auto exptDb = svr->getSegmentMgr()->getDb(&sess, 0, mgl::LockMode::LOCK_IS);
+    EXPECT_TRUE(exptDb.ok());
+
+    auto store = exptDb.value().store;
+    EXPECT_EQ(store->getCFOption(ColumnFamilyNumber::ColumnFamily_Default,
+                                 "rocks.enable_blob_files"),
+              df_status);
+    EXPECT_EQ(store->getCFOption(ColumnFamilyNumber::ColumnFamily_Binlog,
+                                 "rocks.enable_blob_files"),
+              bl_status);
+  }
+}
+
+void testCFConfigSetAndGet(std::shared_ptr<ServerEntry> master) {
+  auto ctx = std::make_shared<asio::io_context>();
+  auto session = makeSession(master, ctx);
+  {
+    session->setArgs({"config", "set", "rocks.enable_blob_files", "1"});
+    auto expect = Command::runSessionCmd(session.get());
+    EXPECT_EQ(expect.ok(), true);
+    testRocksCFOptionConfig(master, 1, 1);
+  }
+
+  {
+    session->setArgs({"config", "set", "rocks.enable_blob_files", "0"});
+    auto expect = Command::runSessionCmd(session.get());
+    EXPECT_EQ(expect.ok(), true);
+    testRocksCFOptionConfig(master, 0, 0);
+  }
+
+  {
+    session->setArgs(
+      {"config", "set", "rocks.defaultcf.enable_blob_files", "1"});
+    auto expect = Command::runSessionCmd(session.get());
+    EXPECT_EQ(expect.ok(), true);
+    testRocksCFOptionConfig(master, 1, 0);
+  }
+
+  {
+    session->setArgs(
+      {"config", "set", "rocks.defaultcf.enable_blob_files", "0"});
+    auto expect = Command::runSessionCmd(session.get());
+    EXPECT_EQ(expect.ok(), true);
+    testRocksCFOptionConfig(master, 0, 0);
+  }
+  {
+    session->setArgs(
+      {"config", "set", "rocks.binlogcf.enable_blob_files", "1"});
+    auto expect = Command::runSessionCmd(session.get());
+    EXPECT_EQ(expect.ok(), true);
+    testRocksCFOptionConfig(master, 0, 1);
+  }
+
+  {
+    session->setArgs(
+      {"config", "set", "rocks.binlogcf.enable_blob_files", "0"});
+    auto expect = Command::runSessionCmd(session.get());
+    EXPECT_EQ(expect.ok(), true);
+    testRocksCFOptionConfig(master, 0, 0);
+  }
+}
+TEST(Command, rocksdbCfOptionsCommand) {
+  const auto guard = MakeGuard([]() { destroyEnv(); });
+  EXPECT_TRUE(setupEnv());
+  {
+    std::map<std::string, std::string> configMap = {
+      {"rocks.enable_blob_files", "1"}};
+    auto cfg = makeServerParam(8814, 0, "", true, configMap);
+    getGlobalServer() = makeServerEntry(cfg);
+    testRocksCFOptionConfig(getGlobalServer(), 1, 1);
+    testCFConfigSetAndGet(getGlobalServer());
+#ifndef _WIN32
+    getGlobalServer()->stop();
+    EXPECT_EQ(getGlobalServer().use_count(), 1);
+#endif
+  }
+
+  {
+    std::map<std::string, std::string> configMap = {
+      {"rocks.defaultcf.enable_blob_files", "1"}};
+    auto cfg = makeServerParam(8815, 0, "", true, configMap);
+    getGlobalServer() = makeServerEntry(cfg);
+    testRocksCFOptionConfig(getGlobalServer(), 1, 0);
+    testCFConfigSetAndGet(getGlobalServer());
+#ifndef _WIN32
+    getGlobalServer()->stop();
+    EXPECT_EQ(getGlobalServer().use_count(), 1);
+#endif
+  }
+
+  {
+    std::map<std::string, std::string> configMap = {
+      {"rocks.binlogcf.enable_blob_files", "1"}};
+    auto cfg = makeServerParam(8816, 0, "", true, configMap);
+    getGlobalServer() = makeServerEntry(cfg);
+    testRocksCFOptionConfig(getGlobalServer(), 0, 1);
+    testCFConfigSetAndGet(getGlobalServer());
+#ifndef _WIN32
+    getGlobalServer()->stop();
+    EXPECT_EQ(getGlobalServer().use_count(), 1);
+#endif
+  }
 }
 
 void testSort(bool clusterEnabled) {

--- a/src/tendisplus/storage/rocks/rocks_kvstore.cpp
+++ b/src/tendisplus/storage/rocks/rocks_kvstore.cpp
@@ -1426,12 +1426,12 @@ rocksdb::Options RocksKVStore::options(const std::string cf) {
 }
 
 rocksdb::Options RocksKVStore::defaultColumnOptions() {
-  return options();
+  return options(kDefaultCF);
 }
 
 // Binlog Column different from default
 rocksdb::Options RocksKVStore::binlogColumnOptions() {
-  auto columOpts = options("binlogcf");
+  auto columOpts = options(kBinlogCF);
   for (int i = 0; i < ROCKSDB_NUM_LEVELS; ++i) {
     columOpts.compression_per_level[i] =
       rocksGetCompressType(_cfg->rocksCompressType);
@@ -3249,8 +3249,10 @@ Status RocksKVStore::setOptionDynamic(const std::string& option,
   auto cf = ColumnFamilyNumber::ColumnFamily_All;
   if (isCfOption) {
     if (specialCf == "") {
+      cf = ColumnFamilyNumber::ColumnFamily_All;
+    } else if (specialCf == kDefaultCF) {
       cf = ColumnFamilyNumber::ColumnFamily_Default;
-    } else if (specialCf == "binlogcf") {
+    } else if (specialCf == kBinlogCF) {
       cf = ColumnFamilyNumber::ColumnFamily_Binlog;
     } else {
       return {ErrorCodes::ERR_INTERNAL,

--- a/src/tendisplus/storage/rocks/rocks_kvstore.h
+++ b/src/tendisplus/storage/rocks/rocks_kvstore.h
@@ -27,7 +27,8 @@
 #include "tendisplus/storage/kvstore.h"
 
 namespace tendisplus {
-
+static constexpr const char* kDefaultCF = "defaultcf";
+static constexpr const char* kBinlogCF = "binlogcf";
 class RocksKVStore;
 class RocksdbEnv;
 class BackgroundErrorListener;


### PR DESCRIPTION
#424 

修复下面几个错误：
配置文件：
rocks.defaultcf.enable_blob_files 1 （default_cf生效）
动态修改：
config set rocks.enable_blob_files 1 （default_cf和binlog_cf都生效）
config set rocks.defaultcf.enable_blob_files 1 （default_cf生效）

但是还遗留一个问题，就是
config get rocks.enable_blob_files
config get rocks.defaultcf.enable_blob_files
config get rocks.binlogcf.enable_blob_files
三个返回结果无法真实反映开闭状态，后续需要进一步优化。


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix #424 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Code follows the code style of this project.
- [ ] Change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.