### PR TITLE
optimize the performance of string type with big value

### DIFF
--- a/.github/workflows/Tendis-CI.yml
+++ b/.github/workflows/Tendis-CI.yml
@@ -2,7 +2,7 @@ name: Tendis-build-CI
 # Controls when the action will run.
 on:
   pull_request:
-    branches: [unstable, master]
+    branches: [unstable, master, 2.8.tx]
   push:
     branches: []
 jobs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,9 @@ if(CMAKE_COMPILER_IS_GNUCC)
             "cd ${PROJECT_SOURCE_DIR}/src/thirdparty/rocksdb/rocksdb\;
              git am --abort\;
              git am -s ../../patch/0001-add-statistic-for-sst-file-info.patch\;
-             git am -s ../../patch/0002-add-latency-statistic-log.patch\; ")
+             git am -s ../../patch/0002-add-latency-statistic-log.patch\;
+             git am -s ../../patch/0003-better-control-of-blobldb-space-amp.patch\;
+             ")
 		execute_process(COMMAND bash "-c" ${patchCommand})
         set(ROCKSDB_DIR "${PROJECT_SOURCE_DIR}/src/thirdparty/rocksdb")
     else()

--- a/src/tendisplus/cluster/migrate_receiver.cpp
+++ b/src/tendisplus/cluster/migrate_receiver.cpp
@@ -179,18 +179,9 @@ Status ChunkMigrateReceiver::supplySetKV(const std::string& key,
   // only RT_*_META need recover, it's saved as RT_DATA_META in RecordKey
   // if RecordValue's type is RT_KV need ignore recovering.
   if (expRk.value().getRecordType() == RecordType::RT_DATA_META) {
-    if (expRv.value().getTtl() > 0 &&
-        expRv.value().getRecordType() != RecordType::RT_KV) {
-      // add new index entry
-      TTLIndex n_ictx(expRk.value().getPrimaryKey(),
-                      expRv.value().getRecordType(),
-                      expRk.value().getDbId(),
-                      expRv.value().getTtl());
-      s = txn->setKV(n_ictx.encode(),
-                     RecordValue(RecordType::RT_TTL_INDEX).encode());
-      if (!s.ok()) {
-        return s;
-      }
+    s = updateTTLIndex(kvstore, expRk.value(), expRv.value(), txn.get(), 0);
+    if (!s.ok()) {
+      return s;
     }
   }
 
@@ -258,16 +249,9 @@ Status ChunkMigrateReceiver::PutSingleBatch(const std::string& migrateBatch,
     // only RT_*_META need recover, it's saved as RT_DATA_META in RecordKey
     // if RecordValue's type is RT_KV need ignore recovering.
     if (expRk.value().getRecordType() == RecordType::RT_DATA_META) {
-      if (expRv.value().getTtl() > 0 &&
-          expRv.value().getRecordType() != RecordType::RT_KV) {
-        // add new index entry
-        TTLIndex n_ictx(expRk.value().getPrimaryKey(),
-                        expRv.value().getRecordType(),
-                        expRk.value().getDbId(),
-                        expRv.value().getTtl());
-        s = txn->setKV(n_ictx.encode(),
-                       RecordValue(RecordType::RT_TTL_INDEX).encode());
-        RET_IF_ERR(s);
+      s = updateTTLIndex(kvstore, expRk.value(), expRv.value(), txn.get(), 0);
+      if (!s.ok()) {
+        return s;
       }
     }
     batchItem++;

--- a/src/tendisplus/commands/command.cpp
+++ b/src/tendisplus/commands/command.cpp
@@ -40,6 +40,99 @@ std::unordered_map<std::string, Command*>& adminCommandMap() {
   return map;
 }
 
+// val._ttl is new ttl
+bool needTTLIndex(PStore store, const RecordValue& val) {
+  if (val.getRecordType() != RecordType::RT_KV) {
+    return true;
+  }
+  uint64_t minBlobSize = store->getCFOption(
+    ColumnFamilyNumber::ColumnFamily_Default, "rocks.min_blob_size");
+  bool enableBlobFiles = store->getCFOption(
+    ColumnFamilyNumber::ColumnFamily_Default, "rocks.enable_blob_files");
+  if (enableBlobFiles && val.encode().size() >= minBlobSize &&
+      store->getCfg()->noexpireBlob && val.getTtl()) {
+    return true;
+  }
+  return false;
+}
+
+// val._ttl is new ttl
+Status updateTTLIndex(PStore store,
+                      const RecordKey& key,
+                      const RecordValue& val,
+                      Transaction* txn,
+                      uint64_t oldExpire = 0) {
+  Status status;
+  if (!needTTLIndex(store, val)) {
+    return status;
+  }
+  uint64_t oldTTL = 0;
+  if (val.getRecordType() == RecordType::RT_KV) {
+    // get kv extra info
+    RecordKey keyEtra(key.getChunkId(),
+                      key.getDbId(),
+                      RecordType::RT_KV_EXTRA,
+                      key.getPrimaryKey(),
+                      "");
+    Expected<RecordValue> oldExtraValue = store->getKV(keyEtra, txn);
+    if (oldExtraValue.ok()) {
+      if (oldExtraValue.value().getValue().size() == sizeof(uint64_t)) {
+        oldTTL = int64Decode(oldExtraValue.value().getValue().c_str());
+      }
+    } else if (oldExtraValue.status().code() != ErrorCodes::ERR_NOTFOUND) {
+      return oldExtraValue.status();
+    }
+    // save kv extra info
+    std::string ttl;
+    ttl.resize(sizeof(uint64_t));
+    int64Encode(&ttl[0], val.getTtl());
+    RecordValue newExtraValue(
+      ttl, RecordType::RT_KV_EXTRA, val.getVersionEP(), 0);
+    status = txn->setKV(keyEtra.encode(), newExtraValue.encode());
+    if (!status.ok()) {
+      return status;
+    }
+  } else {
+    oldTTL = oldExpire;
+  }
+
+  // delete old index entry
+  if (oldTTL != 0) {
+    TTLIndex ictx(
+      key.getPrimaryKey(), val.getRecordType(), key.getDbId(), oldTTL);
+
+    status = txn->delKV(ictx.encode());
+    if (!status.ok()) {
+      return status;
+    }
+  }
+
+  if (val.getTtl() != 0) {
+    //  add new index entry
+    TTLIndex ictx(
+      key.getPrimaryKey(), val.getRecordType(), key.getDbId(), val.getTtl());
+    return txn->setKV(ictx.encode(),
+                      RecordValue(RecordType::RT_TTL_INDEX).encode());
+  }
+  return status;
+}
+
+Status deleteTTLIndex(PStore store,
+                      const RecordKey& key,
+                      const RecordValue& val,
+                      Transaction* txn) {
+  Status status;
+  if (!needTTLIndex(store, val)) {
+    return status;
+  }
+  if (val.getTtl() != 0) {
+    //  del index entry
+    TTLIndex ictx(
+      key.getPrimaryKey(), val.getRecordType(), key.getDbId(), val.getTtl());
+    return txn->delKV(ictx.encode());
+  }
+  return status;
+}
 Command::Command(const std::string& name, const char* sflags)
   : _name(toLower(name)),
     _sflags(sflags),
@@ -357,7 +450,7 @@ Status Command::delKeyPessimisticInLock(Session* sess,
                                         uint32_t storeId,
                                         const RecordKey& mk,
                                         RecordType valueType,
-                                        const TTLIndex* ictx) {
+                                        const RecordValue& rv) {
   std::string keyEnc = mk.encode();
   auto server = sess->getServerEntry();
 
@@ -388,12 +481,11 @@ Status Command::delKeyPessimisticInLock(Session* sess,
     return s;
   }
 
-  if (ictx && ictx->getType() != RecordType::RT_KV) {
-    Status s = txn->delKV(ictx->encode());
-    if (!s.ok()) {
-      return s;
-    }
+  s = deleteTTLIndex(kvstore, mk, rv, txn.get());
+  if (!s.ok()) {
+    return s;
   }
+
 
   Expected<uint64_t> commitStatus = txn->commit();
   return commitStatus.status();
@@ -492,7 +584,7 @@ Status Command::delKeyOptimismInLock(Session* sess,
                                      const RecordKey& rk,
                                      RecordType valueType,
                                      Transaction* txn,
-                                     const TTLIndex* ictx) {
+                                     const RecordValue& rv) {
   auto s = Command::partialDelSubKeys(sess,
                                       storeId,
                                       std::numeric_limits<uint32_t>::max(),
@@ -500,7 +592,7 @@ Status Command::delKeyOptimismInLock(Session* sess,
                                       valueType,
                                       true,
                                       txn,
-                                      ictx);
+                                      rv);
   return s.status();
 }
 
@@ -644,7 +736,7 @@ Expected<uint32_t> Command::partialDelSubKeys(Session* sess,
                                               RecordType valueType,
                                               bool deleteMeta,
                                               Transaction* txn,
-                                              const TTLIndex* ictx) {
+                                              const RecordValue& rv) {
   Status s(ErrorCodes::ERR_OK, "");
   auto guard = MakeGuard([&s] {
     if (!s.ok()) {
@@ -663,6 +755,12 @@ Expected<uint32_t> Command::partialDelSubKeys(Session* sess,
 
   PStore kvstore = expdb.value().store;
   INVARIANT_D(mk.getRecordType() == RecordType::RT_DATA_META);
+
+  s = deleteTTLIndex(kvstore, mk, rv, txn);
+  if (!s.ok()) {
+    return s;
+  }
+
   if (valueType == RecordType::RT_KV) {
     s = kvstore->delKV(mk, txn);
     RET_IF_ERR(s);
@@ -747,10 +845,6 @@ Expected<uint32_t> Command::partialDelSubKeys(Session* sess,
     RET_IF_ERR(s);
   }
 
-  if (ictx && ictx->getType() != RecordType::RT_KV) {
-    s = txn->delKV(ictx->encode());
-    RET_IF_ERR(s);
-  }
 
   return pendingDelete.size();
 }
@@ -791,16 +885,11 @@ Status Command::delKeyAndTTL(Session* sess,
     return s;
   }
 
-  if (val.getTtl() > 0 && val.getRecordType() != RecordType::RT_KV) {
-    TTLIndex ictx(mk.getPrimaryKey(),
-                  val.getRecordType(),
-                  sess->getCtx()->getDbId(),
-                  val.getTtl());
-    s = txn->delKV(ictx.encode());
-    if (!s.ok()) {
-      return s;
-    }
+  s = deleteTTLIndex(kvstore, mk, val, txn);
+  if (!s.ok()) {
+    return s;
   }
+
   return s;
 }
 
@@ -838,16 +927,14 @@ Status Command::delKey(Session* sess,
       return cnt.status();
     }
 
-    TTLIndex ictx(
-      key, valueType, sess->getCtx()->getDbId(), eValue.value().getTtl());
     if (useDeleteRange(cnt.value(), valueType, server->getParams())) {
       LOG(INFO) << "bigkey delete:" << hexlify(mk.getPrimaryKey())
                 << ",rcdType:" << rt2Char(valueType) << ",size:" << cnt.value();
       return Command::delKeyPessimisticInLock(
-        sess, storeId, mk, valueType, ictx.getTTL() > 0 ? &ictx : nullptr);
+        sess, storeId, mk, valueType, eValue.value());
     } else {
       Status s = Command::delKeyOptimismInLock(
-        sess, storeId, mk, valueType, txn, ictx.getTTL() > 0 ? &ictx : nullptr);
+        sess, storeId, mk, valueType, txn, eValue.value());
       if (s.code() == ErrorCodes::ERR_COMMIT_RETRY && i != RETRY_CNT - 1) {
         continue;
       }
@@ -936,12 +1023,11 @@ Expected<RecordValue> Command::expireKeyIfNeeded(Session* sess,
       return cnt.status();
     }
 
-    TTLIndex ictx(key, valueType, sess->getCtx()->getDbId(), targetTtl);
     if (useDeleteRange(cnt.value(), valueType, server->getParams())) {
       LOG(INFO) << "bigkey delete:" << hexlify(mk.getPrimaryKey())
                 << ",rcdType:" << rt2Char(valueType) << ",size:" << cnt.value();
       Status s = Command::delKeyPessimisticInLock(
-        sg.getSession(), storeId, mk, valueType, &ictx);
+        sg.getSession(), storeId, mk, valueType, eValue.value());
       if (s.ok()) {
         return {ErrorCodes::ERR_EXPIRED, ""};
       } else {
@@ -949,7 +1035,7 @@ Expected<RecordValue> Command::expireKeyIfNeeded(Session* sess,
       }
     } else {
       Status s = Command::delKeyOptimismInLock(
-        sg.getSession(), storeId, mk, valueType, txn.get(), &ictx);
+        sg.getSession(), storeId, mk, valueType, txn.get(), eValue.value());
       if (!s.ok()) {
         return s;
       }

--- a/src/tendisplus/commands/command.h
+++ b/src/tendisplus/commands/command.h
@@ -21,6 +21,16 @@
 #include "tendisplus/utils/status.h"
 
 namespace tendisplus {
+bool needTTLIndex(PStore store, const RecordValue& val);
+Status updateTTLIndex(PStore store,
+                      const RecordKey& key,
+                      const RecordValue& val,
+                      Transaction* txn,
+                      uint64_t oldExpire);
+Status deleteTTLIndex(PStore store,
+                      const RecordKey& key,
+                      const RecordValue& val,
+                      Transaction* txn);
 
 class Command {
  public:
@@ -144,14 +154,14 @@ class Command {
                                         uint32_t storeId,
                                         const RecordKey& rk,
                                         RecordType valueType,
-                                        const TTLIndex* ictx = nullptr);
+                                        const RecordValue& rv);
 
   static Status delKeyOptimismInLock(Session* sess,
                                      uint32_t storeId,
                                      const RecordKey& rk,
                                      RecordType valueType,
                                      Transaction* txn,
-                                     const TTLIndex* ictx = nullptr);
+                                     const RecordValue& rv);
   static bool useDeleteRange(uint64_t eleCount,
                              RecordType type,
                              const std::shared_ptr<ServerParams>& cfg);
@@ -169,7 +179,7 @@ class Command {
                                               RecordType valueType,
                                               bool deleteMeta,
                                               Transaction* txn,
-                                              const TTLIndex* ictx = nullptr);
+                                              const RecordValue& rv);
 
   const std::string _name;
   /* Flags as string representation, one char per flag. */

--- a/src/tendisplus/commands/command_test.cpp
+++ b/src/tendisplus/commands/command_test.cpp
@@ -2379,7 +2379,7 @@ void testRocksOptionCommand(std::shared_ptr<ServerEntry> svr) {
     EXPECT_TRUE(exptDb.ok());
 
     auto store = exptDb.value().store;
-    EXPECT_EQ(store->getOption("rocks.max_background_jobs"), 3);
+    EXPECT_EQ(store->getDBOption("rocks.max_background_jobs"), 3);
   }
 
   sess.setArgs({"CONFIG", "GET", "rocks.max_background_jobs"});
@@ -2399,7 +2399,7 @@ void testRocksOptionCommand(std::shared_ptr<ServerEntry> svr) {
     EXPECT_TRUE(exptDb.ok());
 
     auto store = exptDb.value().store;
-    EXPECT_EQ(store->getOption("rocks.max_open_files"), 3000);
+    EXPECT_EQ(store->getDBOption("rocks.max_open_files"), 3000);
   }
 
   sess.setArgs({"CONFIG", "GET", "rocks.max_open_files"});
@@ -2419,7 +2419,7 @@ void testRocksOptionCommand(std::shared_ptr<ServerEntry> svr) {
     EXPECT_TRUE(exptDb.ok());
 
     auto store = exptDb.value().store;
-    EXPECT_EQ(store->getOption("rocks.max_open_files"), -1);
+    EXPECT_EQ(store->getDBOption("rocks.max_open_files"), -1);
   }
 
   sess.setArgs({"CONFIG", "GET", "rocks.max_open_files"});
@@ -2439,7 +2439,9 @@ void testRocksOptionCommand(std::shared_ptr<ServerEntry> svr) {
     EXPECT_TRUE(exptDb.ok());
 
     auto store = exptDb.value().store;
-    EXPECT_EQ(store->getOption("rocks.periodic_compaction_seconds"), 3);
+    EXPECT_EQ(store->getCFOption(ColumnFamilyNumber::ColumnFamily_Default,
+                                 "rocks.periodic_compaction_seconds"),
+              3);
   }
 
   sess.setArgs({"CONFIG", "GET", "rocks.periodic_compaction_seconds"});

--- a/src/tendisplus/commands/debug.cpp
+++ b/src/tendisplus/commands/debug.cpp
@@ -51,6 +51,162 @@
 
 namespace tendisplus {
 
+class IterAllGeneric : public Command {
+ public:
+  IterAllGeneric(const std::string& name, const char* sflags)
+    : Command(name, sflags) {}
+
+  virtual Status callBack(Session* sess,
+                          PStore kvstore,
+                          const RecordKey& rk,
+                          const RecordValue& rv) = 0;
+  Status scanAllKeys(Session* sess) {
+    Status status;
+    auto server = sess->getServerEntry();
+    std::bitset<CLUSTER_SLOTS> checkSlots;
+    bool enableCluster = server->getParams()->clusterEnabled;
+    if (enableCluster) {
+      auto myself = server->getClusterMgr()->getClusterState()->getMyselfNode();
+      checkSlots = myself->nodeIsMaster() ? myself->getSlots()
+                                          : myself->getMaster()->getSlots();
+    }
+
+    for (ssize_t i = 0; i < server->getKVStoreCount(); i++) {
+      auto expdb =
+        server->getSegmentMgr()->getDb(sess, i, mgl::LockMode::LOCK_IS);
+      if (!expdb.ok()) {
+        if (expdb.status().code() == ErrorCodes::ERR_STORE_NOT_OPEN) {
+          continue;
+        }
+        return expdb.status();
+      }
+
+      PStore kvstore = expdb.value().store;
+      auto ptxn = sess->getCtx()->createTransaction(kvstore);
+      if (!ptxn.ok()) {
+        return ptxn.status();
+      }
+
+      auto cursor = ptxn.value()->createDataCursor();
+
+      cursor->seek("");
+      while (true) {
+        Expected<Record> exptRcd = cursor->next();
+        if (exptRcd.status().code() == ErrorCodes::ERR_EXHAUST) {
+          break;
+        }
+        if (!exptRcd.ok()) {
+          return exptRcd.status();
+        }
+
+        if (exptRcd.value().getRecordKey().getDbId() !=
+            sess->getCtx()->getDbId()) {
+          continue;
+        }
+        // NOTE(vinchen):
+        // RecordType::RT_TTL_INDEX and RecordType::BINLOG
+        // is always at the last of rocksdb, and the chunkid is very big
+        auto chunkId = exptRcd.value().getRecordKey().getChunkId();
+        if (chunkId >= server->getSegmentMgr()->getChunkSize()) {
+          break;
+        }
+        // NOTE(wayenchen) ignore slot not belong to me
+        if (enableCluster && !checkSlots.test(chunkId)) {
+          continue;
+        }
+
+        callBack(sess,
+                 kvstore,
+                 exptRcd.value().getRecordKey(),
+                 exptRcd.value().getRecordValue());
+      }
+    }
+    return status;
+  }
+};
+
+// Build Str TTL Index
+class BstiCommand : public IterAllGeneric {
+ public:
+  BstiCommand() : IterAllGeneric("bsti", "ws") {}
+
+  ssize_t arity() const {
+    return 1;
+  }
+
+  int32_t firstkey() const {
+    return 0;
+  }
+
+  int32_t lastkey() const {
+    return 0;
+  }
+
+  int32_t keystep() const {
+    return 0;
+  }
+
+  bool sameWithRedis() const {
+    return false;
+  }
+
+  Status callBack(Session* sess,
+                  PStore kvstore,
+                  const RecordKey& rk,
+                  const RecordValue& rv) override {
+    Status status;
+    if (rv.getRecordType() != RecordType::RT_KV) {
+      return status;
+    }
+    if (!needTTLIndex(kvstore, rv)) {
+      return status;
+    }
+
+    std::vector<std::string> keys;
+    keys.push_back(rk.getPrimaryKey());
+    std::vector<int> index;
+    index.push_back(0);
+    auto locklist = sess->getServerEntry()->getSegmentMgr()->getAllKeysLocked(
+      sess, keys, index, mgl::LockMode::LOCK_X, getFlags());
+    if (!locklist.ok()) {
+      return locklist.status();
+    }
+
+    auto eTxn = kvstore->createTransaction(nullptr);
+    if (!eTxn.ok()) {
+      LOG(ERROR) << "createTransaction failed:" << eTxn.status().toString();
+      return eTxn.status();
+    }
+    std::unique_ptr<Transaction> txn = std::move(eTxn.value());
+
+    _updateNum++;
+    status = updateTTLIndex(kvstore, rk, rv, txn.get(), 0);
+    if (!status.ok()) {
+      return status;
+    }
+
+    auto commitStatus = txn->commit();
+    if (!commitStatus.ok()) {
+      return commitStatus.status();
+    }
+    return status;
+  }
+
+  Expected<std::string> run(Session* sess) final {
+    LOG(INFO) << "Build Str TTL Index begin.";
+    _updateNum = 0;
+    auto s = scanAllKeys(sess);
+    LOG(INFO) << "Build Str TTL Index end, updateNum:" << _updateNum;
+    if (!s.ok()) {
+      return s;
+    }
+    return Command::fmtLongLong(_updateNum);
+  }
+
+ private:
+  uint64_t _updateNum;
+} bstiCmd;
+
 class KeysCommand : public Command {
  public:
   KeysCommand() : Command("keys", "rs") {}

--- a/src/tendisplus/commands/expire.cpp
+++ b/src/tendisplus/commands/expire.cpp
@@ -27,6 +27,7 @@ Expected<bool> expireBeforeNow(Session* sess,
   return Command::delKeyChkExpire(sess, key, type, txn);
 }
 
+
 // return true if exists
 // return false if not exists
 // return error if has error
@@ -68,33 +69,18 @@ Expected<bool> expireAfterNow(Session* sess,
       return eValue.status();
     }
     auto rv = eValue.value();
-    auto vt = rv.getRecordType();
     Status s;
 
-    if (vt != RecordType::RT_KV) {
-      // delete old index entry
-      auto oldTTL = rv.getTtl();
-      if (oldTTL != 0) {
-        TTLIndex o_ictx(key, vt, pCtx->getDbId(), oldTTL);
-
-        s = txn->delKV(o_ictx.encode());
-        if (!s.ok()) {
-          return s;
-        }
-      }
-
-      // add new index entry
-      TTLIndex n_ictx(key, vt, pCtx->getDbId(), expireAt);
-      s = txn->setKV(n_ictx.encode(),
-                     RecordValue(RecordType::RT_TTL_INDEX).encode());
-      if (!s.ok()) {
-        return s;
-      }
-    }
-
+    uint64_t oldTTl = rv.getTtl();
     // update
     rv.setTtl(expireAt);
     rv.setVersionEP(pCtx->getVersionEP());
+
+    s = updateTTLIndex(kvstore, rk, rv, txn, oldTTl);
+    if (!s.ok()) {
+      return s;
+    }
+
     s = kvstore->setKV(rk, rv, txn);
     if (!s.ok()) {
       return s;
@@ -111,7 +97,7 @@ Expected<std::string> expireGeneric(Session* sess,
                                     int64_t expireAt,
                                     const std::string& key,
                                     Transaction* txn) {
-  if (expireAt >= (int64_t)msSinceEpoch() ||
+  if (expireAt >= static_cast<int64_t>(msSinceEpoch()) ||
       sess->getServerEntry()->getParams()->noexpire) {
     bool atLeastOne = false;
     for (auto type : {RecordType::RT_DATA_META}) {

--- a/src/tendisplus/commands/kv.cpp
+++ b/src/tendisplus/commands/kv.cpp
@@ -123,6 +123,13 @@ Expected<std::string> setGeneric(Session* sess,
   if (!status.ok()) {
     return status;
   }
+
+
+  status = updateTTLIndex(store, key, val, txn, 0);
+  if (!status.ok()) {
+    return status;
+  }
+
   if (endTxn) {
     Expected<uint64_t> exptCommit = sess->getCtx()->commitTransaction(txn);
     if (!exptCommit.ok()) {
@@ -1054,7 +1061,7 @@ class CasCommand : public GetSetGeneral {
       return ret;
     }
 
-    if ((int64_t)ecas.value() != oldValue.value().getCas() &&
+    if (static_cast<int64_t>(ecas.value()) != oldValue.value().getCas() &&
         oldValue.value().getCas() != -1) {
       return {ErrorCodes::ERR_CAS, "cas unmatch"};
     }
@@ -2144,19 +2151,9 @@ class RenameGenericCommand : public Command {
     if (!s.ok()) {
       return s;
     }
-    if (rv.value().getRecordType() != RecordType::RT_KV &&
-        rv.value().getTtl() > 0) {
-      TTLIndex ictx(dst,
-                    rv.value().getRecordType(),
-                    sess->getCtx()->getDbId(),
-                    rv.value().getTtl());
-      if (ictx.getType() != RecordType::RT_KV) {
-        s = dptxn.value()->setKV(
-          ictx.encode(), RecordValue(RecordType::RT_TTL_INDEX).encode());
-        if (!s.ok()) {
-          return s;
-        }
-      }
+    s = updateTTLIndex(dststore, rk, rv.value(), dptxn.value(), 0);
+    if (!s.ok()) {
+      return s;
     }
 
     if (rv.value().getRecordType() == RecordType::RT_KV) {
@@ -2389,8 +2386,8 @@ class BitFieldCommand : public Command {
     conv.u = getUnsignedBitfield(value, offset, bits);
     ret = conv.i;
 
-    if (ret & ((uint64_t)1 << (bits - 1)))
-      ret |= ((uint64_t)-1) << bits;
+    if (ret & (static_cast<uint64_t>(1) << (bits - 1)))
+      ret |= static_cast<uint64_t>(-1) << bits;
 
     return ret;
   }
@@ -2400,11 +2397,12 @@ class BitFieldCommand : public Command {
                                     uint64_t bits,
                                     BFOverFlowType owtype,
                                     uint64_t* newVal) {
-    uint64_t max = (bits == 64) ? UINT64_MAX : (((uint64_t)1 << bits) - 1);
+    uint64_t max =
+      (bits == 64) ? UINT64_MAX : ((static_cast<uint64_t>(1) << bits) - 1);
     int64_t maxincr = max - value;
     int64_t minincr = -value;
     auto handleWrap = [&]() {
-      uint64_t mask = ((uint64_t)-1) << bits;
+      uint64_t mask = static_cast<uint64_t>(-1) << bits;
       uint64_t res = value + incr;
       res &= ~mask;
       *newVal = res;
@@ -2435,15 +2433,16 @@ class BitFieldCommand : public Command {
                                   uint64_t bits,
                                   BFOverFlowType owtype,
                                   int64_t* newVal) {
-    int64_t max = (bits == 64) ? INT64_MAX : (((int64_t)1 << (bits - 1)) - 1);
+    int64_t max =
+      (bits == 64) ? INT64_MAX : ((static_cast<int64_t>(1) << (bits - 1)) - 1);
     int64_t min = (-max) - 1;
 
     int64_t maxincr = max - value;
     int64_t minincr = min - value;
 
     auto handleWrap = [&]() {
-      uint64_t mask = ((uint64_t)-1) << bits;
-      uint64_t msb = (uint64_t)1 << (bits - 1);
+      uint64_t mask = static_cast<uint64_t>(-1) << bits;
+      uint64_t msb = static_cast<uint64_t>(1) << (bits - 1);
       uint64_t a = value, b = incr, c;
       c = a + b;
 
@@ -2481,7 +2480,8 @@ class BitFieldCommand : public Command {
                            uint64_t bits,
                            uint64_t value) {
     for (size_t i = 0; i < bits; i++) {
-      uint64_t bitval = (value & ((uint64_t)1 << (bits - 1 - i))) != 0;
+      uint64_t bitval =
+        (value & (static_cast<uint64_t>(1) << (bits - 1 - i))) != 0;
       uint64_t byte = offset >> 3;
       uint64_t bit = 7 - (offset & 0x7);
       uint8_t byteval = static_cast<uint8_t>((*buf)[byte]);

--- a/src/tendisplus/server/server_params.h
+++ b/src/tendisplus/server/server_params.h
@@ -487,7 +487,7 @@ class ServerParams {
   uint32_t dbNum = CONFIG_DEFAULT_DBNUM;
 
   bool noexpire = false;
-  bool noexpireBlob = false;
+  bool noexpireBlob = true;
   uint64_t maxBinlogKeepNum = 1;
   uint32_t minBinlogKeepSec = 3600;
   uint64_t slaveBinlogKeepNum = 1;

--- a/src/tendisplus/storage/kvstore.h
+++ b/src/tendisplus/storage/kvstore.h
@@ -498,6 +498,7 @@ class KVStore {
   virtual void appendJSONStat(
     rapidjson::PrettyWriter<rapidjson::StringBuffer>&) const = 0;
 
+  virtual const std::shared_ptr<ServerParams>& getCfg() const = 0;
   uint64_t getBinlogTime() const;
   void setBinlogTime(uint64_t timestamp);
   uint64_t getCurrentTime() const;
@@ -506,7 +507,10 @@ class KVStore {
   virtual Status setCompactOnDeletionCollectorFactory(
     const std::string& option,
     std::shared_ptr<tendisplus::ServerParams> cfg) = 0;
-  virtual int64_t getOption(const std::string& option) = 0;
+  virtual int64_t getDBOption(const std::string& option) = 0;
+  virtual int64_t getCFOption(ColumnFamilyNumber cf,
+                              const std::string& option) = 0;
+
 
   KVStoreStat stat;
 

--- a/src/tendisplus/storage/record.cpp
+++ b/src/tendisplus/storage/record.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -123,6 +124,8 @@ uint8_t rt2Char(RecordType t) {
     // the right most part.
     case RecordType::RT_BINLOG:
       return std::numeric_limits<uint8_t>::max();
+    case RecordType::RT_KV_EXTRA:
+      return 'k';
     default:
       LOG(FATAL) << "invalid recordtype:" << static_cast<uint32_t>(t);
       INVARIANT_D(0);
@@ -199,6 +202,8 @@ RecordType char2Rt(uint8_t t) {
       return RecordType::RT_TTL_INDEX;
     case std::numeric_limits<uint8_t>::max():
       return RecordType::RT_BINLOG;
+    case 'k':
+      return RecordType::RT_KV_EXTRA;
     default:
       LOG(ERROR) << "invalid rcdchr:" << static_cast<uint32_t>(t);
       // never reaches here, void compiler complain
@@ -947,7 +952,8 @@ Expected<bool> RecordValue::validate(const std::string& value,
     return {ErrorCodes::ERR_DECODE, "invalid pieceSize"};
   }
 
-  if (totalSize != value.size() - offset && totalSize != (uint64_t)-1) {
+  if (totalSize != value.size() - offset &&
+      totalSize != static_cast<uint64_t>(-1)) {
     return {ErrorCodes::ERR_DECODE, "invalid totalSize"};
   }
 
@@ -1952,8 +1958,8 @@ Expected<VersionMeta> VersionMeta::decode(const RecordKey& rk,
   auto nameMeta = rk.getPrimaryKey();
   std::string name = nameMeta.substr(0, nameMeta.size() - 5);
 
-  return VersionMeta((uint64_t)doc["timestamp"].GetUint64(),
-                     (uint64_t)(doc["version"].GetUint64()),
+  return VersionMeta(static_cast<uint64_t>(doc["timestamp"].GetUint64()),
+                     static_cast<uint64_t>(doc["version"].GetUint64()),
                      name);
 }
 

--- a/src/tendisplus/storage/record.h
+++ b/src/tendisplus/storage/record.h
@@ -66,6 +66,8 @@ enum class RecordType {
   RT_DATA_META,  /* For key type in RecordKey */
   RT_TBITMAP_META,
   RT_TBITMAP_ELE,
+  RT_KV_EXTRA  // For kv extra info type in RecordKey and RecordValue, such as
+               //   ttl info if KV has big value
 };
 
 uint8_t rt2Char(RecordType t);
@@ -203,14 +205,14 @@ class RecordValue {
                        uint64_t ttl = 0,
                        int64_t cas = -1,
                        uint64_t version = 0,
-                       uint64_t pieceSize = (uint64_t)-1);
+                       uint64_t pieceSize = static_cast<uint64_t>(-1));
   explicit RecordValue(std::string&& val,
                        RecordType type,
                        uint64_t versionEp,
                        uint64_t ttl = 0,
                        int64_t cas = -1,
                        uint64_t version = 0,
-                       uint64_t pieceSize = (uint64_t)-1);
+                       uint64_t pieceSize = static_cast<uint64_t>(-1));
 
   RecordValue(const std::string& val,
               RecordType type,

--- a/src/tendisplus/storage/rocks/rocks_kvstore.cpp
+++ b/src/tendisplus/storage/rocks/rocks_kvstore.cpp
@@ -3385,13 +3385,25 @@ Status RocksKVStore::setCompactOnDeletionCollectorFactory(
 #endif
 }
 
-int64_t RocksKVStore::getOption(const std::string& option) {
+int64_t RocksKVStore::getDBOption(const std::string& option) {
   if (option == "rocks.max_background_jobs") {
     return getBaseDB()->GetDBOptions().max_background_jobs;
   } else if (option == "rocks.max_open_files") {
     return getBaseDB()->GetDBOptions().max_open_files;
-  } else if (option == "rocks.periodic_compaction_seconds") {
-    return getBaseDB()->GetOptions().periodic_compaction_seconds;
+  } else {
+    return -2;
+  }
+}
+
+int64_t RocksKVStore::getCFOption(ColumnFamilyNumber cf,
+                                  const std::string& option) {
+  rocksdb::ColumnFamilyHandle* handle = getColumnFamilyHandle(cf);
+  if (option == "rocks.periodic_compaction_seconds") {
+    return getBaseDB()->GetOptions(handle).periodic_compaction_seconds;
+  } else if (option == "rocks.min_blob_size") {
+    return getBaseDB()->GetOptions(handle).min_blob_size;
+  } else if (option == "rocks.enable_blob_files") {
+    return getBaseDB()->GetOptions(handle).enable_blob_files;
   } else {
     return -2;
   }

--- a/src/tendisplus/storage/rocks/rocks_kvstore.h
+++ b/src/tendisplus/storage/rocks/rocks_kvstore.h
@@ -392,7 +392,7 @@ class RocksKVStore : public KVStore {
   // NOTE(deyukong): this api is only for debug
   std::set<uint64_t> getUncommittedTxns() const;
 
-  const std::shared_ptr<ServerParams>& getCfg() const {
+  const std::shared_ptr<ServerParams>& getCfg() const override {
     return _cfg;
   }
 
@@ -416,7 +416,9 @@ class RocksKVStore : public KVStore {
   Status setCompactOnDeletionCollectorFactory(
     const std::string& option,
     std::shared_ptr<tendisplus::ServerParams> cfg) override;
-  int64_t getOption(const std::string& option) override;
+  int64_t getDBOption(const std::string& option) override;
+  int64_t getCFOption(ColumnFamilyNumber cf,
+                      const std::string& option) override;
   const rocksdb::Snapshot* getSnapshot();
   rocksdb::Iterator* newIterator(const rocksdb::ReadOptions& readOptions,
                                  rocksdb::ColumnFamilyHandle* columnFamily);

--- a/src/thirdparty/patch/0003-better-control-of-blobldb-space-amp.patch
+++ b/src/thirdparty/patch/0003-better-control-of-blobldb-space-amp.patch
@@ -1,0 +1,45 @@
+From 846a40c4378edcd560352a219ba19654a8fd3f2e Mon Sep 17 00:00:00 2001
+From: takenliu <takenliu@tencent.com>
+Date: Tue, 25 Nov 2025 16:09:01 +0800
+Subject: [PATCH] Change the semantics of
+ blob_garbage_collection_force_threshold to provide better control over space
+ amp see details: https://github.com/facebook/rocksdb/pull/13022
+
+---
+ db/version_set.cc | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/db/version_set.cc b/db/version_set.cc
+index 85d9a5326..2fe3ac3bb 100644
+--- a/db/version_set.cc
++++ b/db/version_set.cc
+@@ -3763,15 +3763,18 @@ void VersionStorageInfo::ComputeFilesMarkedForForcedBlobGC(
+     const auto& meta = blob_files_[count];
+     assert(meta);
+ 
++    /*
+     if (!meta->GetLinkedSsts().empty()) {
+       // Found the beginning of the next batch of blob files
+       break;
+     }
++    */
+ 
+     sum_total_blob_bytes += meta->GetTotalBlobBytes();
+     sum_garbage_blob_bytes += meta->GetGarbageBlobBytes();
+   }
+ 
++  /*
+   if (count < blob_files_.size()) {
+     const auto& meta = blob_files_[count];
+     assert(meta);
+@@ -3781,6 +3784,7 @@ void VersionStorageInfo::ComputeFilesMarkedForForcedBlobGC(
+       return;
+     }
+   }
++  */
+ 
+   if (sum_garbage_blob_bytes <
+       blob_garbage_collection_force_threshold * sum_total_blob_bytes) {
+-- 
+2.41.3
+


### PR DESCRIPTION
#429 

优化string类型长value情况下的性能。
背景：blobdb功能开启的时候，KVTtlCompactionFilter::FilterBlobByKey()需要读取string类型的value来判断过期。这里读操作量很大。

1.如果string类型的value很长，则为它新增一个RecordType::RT_KV_EXTRA类型的元数据，里面保存ttl信息。并根据这个ttl信息建立TTLIndex（对应的类型为RecordType::RT_TTL_INDEX），由IndexManager来扫描过期索引，进行过期数据的删除操作。
这样FilterBlobByKey()函数里面就不再需要读取value来判断过期，直接返回Decision::kKeep。

2.新增加一个bsti命令（build string ttl index）。
背景：如果集群之前没有设置rocks.enable_blob_files和noexpireblob参数，则没有写入string类型的ttl相关索引，在设置rocks.enable_blob_files和noexpireblob参数之后，依旧无法删除过期的数据，会造成磁盘空间浪费。
为了避免这个问题，可以调用bsti命令进行全盘扫描，并建立这个ttl相关索引，方便后续扫描和删除过期数据。

3.修复rocksdb空间放大无法控制住的问题。
参考：
https://github.com/facebook/rocksdb/pull/13022

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Code follows the code style of this project.
- [ ] Change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.