### PR TITLE
fix(config): support shorthand names for rocksdb compression types

### DIFF
--- a/src/tendisplus/commands/command_test.cpp
+++ b/src/tendisplus/commands/command_test.cpp
@@ -2369,6 +2369,36 @@ void testRocksOptionCommand(std::shared_ptr<ServerEntry> svr) {
   EXPECT_EQ("*2\r\n$27\r\nrocks.blob_compression_type\r\n$3\r\nlz4\r\n",
             expect.value());
 
+  sess.setArgs({"CONFIG", "SET", "rocks.blob_compression_type", "snappy"});
+  expect = Command::runSessionCmd(&sess);
+  EXPECT_TRUE(expect.ok());
+
+  sess.setArgs({"CONFIG", "GET", "rocks.blob_compression_type"});
+  expect = Command::runSessionCmd(&sess);
+  EXPECT_TRUE(expect.ok());
+  EXPECT_EQ("*2\r\n$27\r\nrocks.blob_compression_type\r\n$6\r\nsnappy\r\n",
+            expect.value());
+
+  sess.setArgs({"CONFIG", "SET", "rocks.blob_compression_type", "snappy111"});
+  expect = Command::runSessionCmd(&sess);
+  EXPECT_FALSE(expect.ok());
+
+  sess.setArgs({"CONFIG", "GET", "rocks.blob_compression_type"});
+  expect = Command::runSessionCmd(&sess);
+  EXPECT_TRUE(expect.ok());
+  EXPECT_EQ("*2\r\n$27\r\nrocks.blob_compression_type\r\n$6\r\nsnappy\r\n",
+            expect.value());
+
+  sess.setArgs({"CONFIG", "SET", "rocks.blob_compression_type", "lz4"});
+  expect = Command::runSessionCmd(&sess);
+  EXPECT_TRUE(expect.ok());
+
+  sess.setArgs({"CONFIG", "GET", "rocks.blob_compression_type"});
+  expect = Command::runSessionCmd(&sess);
+  EXPECT_TRUE(expect.ok());
+  EXPECT_EQ("*2\r\n$27\r\nrocks.blob_compression_type\r\n$3\r\nlz4\r\n",
+            expect.value());
+
   std::stringstream ss;
 
   sess.setArgs({"CONFIG", "SET", "rocks.max_background_jobs", "3"});

--- a/src/tendisplus/commands/version.h
+++ b/src/tendisplus/commands/version.h
@@ -6,7 +6,7 @@
 #define SRC_TENDISPLUS_COMMANDS_VERSION_H_
 
 #include <string>
-#define TENDISPLUS_VERSION_PRE "2.8.2-rocksdb-v"
+#define TENDISPLUS_VERSION_PRE "2.8.3-rocksdb-v"
 
 std::string getTendisPlusVersion();
 

--- a/src/tendisplus/storage/rocks/rocks_kvstore.cpp
+++ b/src/tendisplus/storage/rocks/rocks_kvstore.cpp
@@ -967,13 +967,42 @@ rocksdb::Iterator* RocksWBTxn::getIterator(
   return _writeBatch->NewIteratorWithBase(columnFamily, dbIter);
 }
 
+std::string rocksGetCompressionTypeStr(const std::string& typeStr) {
+  static std::unordered_map<std::string, std::string> compression_type_map = {
+    {"none", "kNoCompression"},
+    {"snappy", "kSnappyCompression"},
+    {"zlib", "kZlibCompression"},
+    {"bzip2", "kBZip2Compression"},
+    {"lz4", "kLZ4Compression"},
+    {"lz4hc", "kLZ4HCCompression"},
+    {"xpress", "kXpressCompression"},
+    {"zstd", "kZSTD"},
+    {"zstdnf", "kZSTDNotFinalCompression"},
+    {"disable", "kDisableCompressionOption"}};
+  auto iter = compression_type_map.find(typeStr);
+  if (iter != compression_type_map.end()) {
+    return iter->second;
+  } else {
+    return typeStr;
+  }
+}
+
 rocksdb::CompressionType rocksGetCompressType(const std::string& typeStr) {
-  if (typeStr == "snappy") {
-    return rocksdb::CompressionType::kSnappyCompression;
-  } else if (typeStr == "lz4") {
-    return rocksdb::CompressionType::kLZ4Compression;
-  } else if (typeStr == "none") {
-    return rocksdb::CompressionType::kNoCompression;
+  static std::unordered_map<std::string, rocksdb::CompressionType>
+    compression_type_string_map = {
+      {"none", rocksdb::kNoCompression},
+      {"snappy", rocksdb::kSnappyCompression},
+      {"zlib", rocksdb::kZlibCompression},
+      {"bzip2", rocksdb::kBZip2Compression},
+      {"lz4", rocksdb::kLZ4Compression},
+      {"lz4hc", rocksdb::kLZ4HCCompression},
+      {"xpress", rocksdb::kXpressCompression},
+      {"zstd", rocksdb::kZSTD},
+      {"zstdnf", rocksdb::kZSTDNotFinalCompression},
+      {"disable", rocksdb::kDisableCompressionOption}};
+  auto iter = compression_type_string_map.find(typeStr);
+  if (iter != compression_type_string_map.end()) {
+    return iter->second;
   } else {
     INVARIANT_D(0);
     return rocksdb::CompressionType::kNoCompression;
@@ -3311,7 +3340,11 @@ Status RocksKVStore::setOptionDynamic(const std::string& option,
     }
   }
 
-  map[short_option] = value;
+  if (short_option == "blob_compression_type") {
+    map[short_option] = rocksGetCompressionTypeStr(value);
+  } else {
+    map[short_option] = value;
+  }
 
   if (isDbOption) {
     auto s = getBaseDB()->SetDBOptions(map);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

#438 

> config set rocks.blob_compression_type lz4
(error) ERR:3,msg:Invalid argument: Error parsing:: blob_compression_type

当前需要拼写完整的字符串：
> config set rocks.blob_compression_type kLZ4Compression
OK

修复方法：
检测到“lz4”，帮忙转化为“kLZ4Compression”。这样config命令可以使用简写和完整字符串。

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Code follows the code style of this project.
- [ ] Change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.