### PR TITLE
Fix bug:  The master node may repeatedly dump the same batch of binlogs

### DIFF
--- a/src/tendisplus/storage/rocks/rocks_kvstore.cpp
+++ b/src/tendisplus/storage/rocks/rocks_kvstore.cpp
@@ -1768,11 +1768,11 @@ Expected<TruncateBinlogResult> RocksKVStore::truncateBinlogV2(
 
     result.err = err;
     result.written = written;
-    result.newDump = newDump;
     // slave use timestamp from last dump binlog
     result.timestamp = ts;
     newEnd = newDump - 1;
   }
+  result.newDump = newDump;
 
   auto nextTry = start;
   while (true) {
@@ -1798,7 +1798,7 @@ Expected<TruncateBinlogResult> RocksKVStore::truncateBinlogV2(
     // master use timestamp from deleterange last binlog
     result.timestamp = ts;
   }
-  if (fs == nullptr) {
+  if (result.newStart > result.newDump) {
     result.newDump = result.newStart;
   }
 


### PR DESCRIPTION
The master node may repeatedly dump the same batch of binlogs, when the slave node is busy, leading to repeated timeouts and reconnections in master-slave synchronization.

#447 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Code follows the code style of this project.
- [ ] Change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.