### PR TITLE
fix scan bug

### DIFF
--- a/src/tendisplus/commands/scan.cpp
+++ b/src/tendisplus/commands/scan.cpp
@@ -791,11 +791,11 @@ class ScanCommand : public Command {
     auto kvstoreSlots = getKvstoreSlots(kvstoreId, kvstoreCount, slots);
     auto cursor = txn->createDataCursor();
     cursor->seek(lastScanRecordKey.encode());
+    auto seekSlotId = lastScanRecordKey.getChunkId();
 
     while (result.size() < count && *scanTimes < scanMaxTimes) {
       // get cursor current record and iterate next cursor
       auto expRecord = cursor->next();
-      (*scanTimes)++;
 
       // ERR_EXHAUST means this kv-store has been iterated over
       if (expRecord.status().code() == ErrorCodes::ERR_EXHAUST) {
@@ -828,7 +828,8 @@ class ScanCommand : public Command {
       auto recordSlotId = record.getRecordKey().getChunkId();
       auto recordDbId = record.getRecordKey().getDbId();
       auto recordType = record.getRecordKey().getRecordType();
-      if (!kvstoreSlots.test(recordSlotId) || recordDbId != dbId ||
+      auto isRecordValidSlotId = kvstoreSlots.test(recordSlotId);
+      if (!isRecordValidSlotId || recordDbId != dbId ||
           recordType != RecordType::RT_DATA_META) {
         // seq: this key in DBID db's position
         // means, recordDbId == dbId && recordType == RT_DATA_META
@@ -841,18 +842,23 @@ class ScanCommand : public Command {
         //     recordType == RecordType::RT_DATA_META) {
         //   (*seq)++;
         // }
-        auto nextSlot = getNextSlot(slots, recordSlotId);
+        int32_t nextSlot = recordSlotId;
+        if (!isRecordValidSlotId || recordSlotId == seekSlotId) {
+          nextSlot = getNextSlot(slots, recordSlotId);
+        }
         // nextSlot == -1 means this kv-store has been iterated over
         if (nextSlot == -1) {
           break;
         }
 
         // construct new record key to seek
-        auto nextRecordKey = genRecordKey(nextSlot, dbId, "");
+        seekSlotId = nextSlot;
+        auto nextRecordKey = genRecordKey(seekSlotId, dbId, "");
         cursor->seek(nextRecordKey.encode());
         continue;
       }
 
+      (*scanTimes)++;
       /**
        * check if this record has expired
        * expired key shouldn't increase scanTimes,

--- a/src/tendisplus/commands/scan.cpp
+++ b/src/tendisplus/commands/scan.cpp
@@ -843,7 +843,7 @@ class ScanCommand : public Command {
         //   (*seq)++;
         // }
         int32_t nextSlot = recordSlotId;
-        if (!isRecordValidSlotId || recordSlotId == seekSlotId || 
+        if (!isRecordValidSlotId || recordSlotId == seekSlotId ||
             rt2Char(recordType) > rt2Char(RecordType::RT_DATA_META) ||
             recordDbId > dbId) {
           nextSlot = getNextSlot(slots, recordSlotId);

--- a/src/tendisplus/commands/scan.cpp
+++ b/src/tendisplus/commands/scan.cpp
@@ -844,7 +844,8 @@ class ScanCommand : public Command {
         // }
         int32_t nextSlot = recordSlotId;
         if (!isRecordValidSlotId || recordSlotId == seekSlotId || 
-            rt2Char(recordType) > rt2Char(RecordType::RT_DATA_META)) {
+            rt2Char(recordType) > rt2Char(RecordType::RT_DATA_META) ||
+            recordDbId > dbId) {
           nextSlot = getNextSlot(slots, recordSlotId);
         }
         // nextSlot == -1 means this kv-store has been iterated over

--- a/src/tendisplus/commands/scan.cpp
+++ b/src/tendisplus/commands/scan.cpp
@@ -843,7 +843,8 @@ class ScanCommand : public Command {
         //   (*seq)++;
         // }
         int32_t nextSlot = recordSlotId;
-        if (!isRecordValidSlotId || recordSlotId == seekSlotId) {
+        if (!isRecordValidSlotId || recordSlotId == seekSlotId || 
+            rt2Char(recordType) > rt2Char(RecordType::RT_DATA_META)) {
           nextSlot = getNextSlot(slots, recordSlotId);
         }
         // nextSlot == -1 means this kv-store has been iterated over


### PR DESCRIPTION
Scan非db0的数据时，会出现scan返回数据缺失的问题

nextSlot+1后，scan到的slot可能是比nextSlot大，导致迭代到的第一个key可能是新slot的第一个key，该key的dbId大概率是0，导致其他dbId的数据只能scan到一个slot的数据

所以当cursor seek到下一个slot时，如果slot不是指定的prefix，那就从这个slot的需要的db重新查一次

