### PR TITLE
fix bug: switching the slots and bumping the configEpoch must be executed within the same mutex lock.

### DIFF
--- a/src/tendisplus/cluster/cluster_manager.cpp
+++ b/src/tendisplus/cluster/cluster_manager.cpp
@@ -796,7 +796,8 @@ void ClusterNode::setSession(std::shared_ptr<ClusterSession> sess) {
   INVARIANT_D(!_nodeSession);
   _nodeSession = sess;
   if (sess) {
-    LOG(INFO) << "ClusterNode setSession," << " node name:" << _nodeName
+    LOG(INFO) << "ClusterNode setSession,"
+              << " node name:" << _nodeName
               << " node addr:" << sess->getRemoteRepr()
               << " session id:" << sess->id();
   } else {
@@ -1220,14 +1221,18 @@ Status ClusterState::setSlots(CNodePtr n,
       }
       ++idx;
     }
+    // NOTE(takenliu): switching the slots and bumping the configEpoch
+    //     must be executed within the same mutex lock.
+    if (n == getMyselfNode()) {
+      Status s = clusterBumpConfigEpochWithoutConsensus();
+      if (!s.ok()) {
+        LOG(ERROR) << "setSlots BumpConfigEpoch fail";
+        return s;
+      }
+    }
   }
 
   if (n == getMyselfNode()) {
-    Status s = clusterBumpConfigEpochWithoutConsensus();
-    if (!s.ok()) {
-      LOG(ERROR) << "setSlots BumpConfigEpoch fail";
-      return s;
-    }
     // NOTE(wayenchen) broadcast gossip message if meta change finished
     uint64_t offset = _server->getReplManager()->replicationGetOffset();
     clusterBroadcastPong(CLUSTER_BROADCAST_ALL, offset);
@@ -1302,8 +1307,10 @@ Expected<CNodePtr> ClusterState::clusterHandleRedirect(uint32_t slot,
 
   if (node != _myself) {
     std::stringstream ss;
-    ss << "-" << "MOVED" << " " << slot << " " << node->getNodeIp() << ":"
-       << node->getPort() << "\r\n";
+    ss << "-"
+       << "MOVED"
+       << " " << slot << " " << node->getNodeIp() << ":" << node->getPort()
+       << "\r\n";
     return {ErrorCodes::ERR_MOVED, ss.str()};
   }
   return node;
@@ -1512,7 +1519,8 @@ Expected<std::string> ClusterState::getNodeInfo(CNodePtr n) {
     if (emigrStr.ok()) {
       stream << "migrateSlots:" << emigrStr.value() << "\n";
     } else {
-      stream << "migrateSlots:null" << "\n";
+      stream << "migrateSlots:null"
+             << "\n";
     }
   }
   stream << "flag:" << flags << "\n"
@@ -1911,8 +1919,9 @@ Status ClusterState::clusterSetMaster(CNodePtr node,
   }
 
   LOG(INFO) << "replication set node:" << node->getNodeName()
-            << " as my master," << "ip:" << node->getNodeIp()
-            << " port:" << node->getPort() << ",ignoreRepl:" << ignoreRepl;
+            << " as my master,"
+            << "ip:" << node->getNodeIp() << " port:" << node->getPort()
+            << ",ignoreRepl:" << ignoreRepl;
 
   resetManualFailover();
   _server->CloseAllChannel();
@@ -4406,8 +4415,9 @@ Status ClusterManager::startup() {
     auto name = _clusterState->getMyselfNode()->getNodeName();
     auto state = _clusterState->getClusterState();
     std::string clusterState = (unsigned(state) > 0) ? "OK" : "FAIL";
-    LOG(INFO) << "cluster init success:" << " myself node name " << name
-              << " cluster state is " << clusterState;
+    LOG(INFO) << "cluster init success:"
+              << " myself node name " << name << " cluster state is "
+              << clusterState;
   }
 
   std::shared_ptr<ServerParams> params = _svr->getParams();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

改变slot和提升configEpoch需要在同一个mutex锁下，不然会带来一致性问题。

#451 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Code follows the code style of this project.
- [ ] Change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.