### PR TITLE
feat(expire): use LOCK_S for read commands to reduce hot key contention

### DIFF
--- a/src/tendisplus/commands/command.cpp
+++ b/src/tendisplus/commands/command.cpp
@@ -11,11 +11,11 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
 #include "tendisplus/lock/lock.h"
+#include "tendisplus/storage/kvstore.h"
 #include "tendisplus/storage/record.h"
 #include "tendisplus/utils/invariant.h"
 #include "tendisplus/utils/scopeguard.h"
@@ -25,7 +25,7 @@
 namespace tendisplus {
 
 std::mutex Command::_mutex;
-mgl::LockMode Command::_expRdLk = mgl::LockMode::LOCK_X;
+mgl::LockMode Command::_expRdLk = mgl::LockMode::LOCK_S;
 
 std::map<std::string, uint64_t> Command::_unSeenCmds = {};
 
@@ -913,142 +913,158 @@ Status Command::delKey(Session* sess,
 
   RecordKey mk(expdb.value().chunkId, pCtx->getDbId(), tp, key, "");
 
-  for (uint32_t i = 0; i < RETRY_CNT; ++i) {
-    Expected<RecordValue> eValue = kvstore->getKV(mk, txn);
-    if (!eValue.ok()) {
-      if (eValue.status().code() == ErrorCodes::ERR_NOTFOUND) {
-        return {ErrorCodes::ERR_OK, ""};
-      }
-      return eValue.status();
+  Expected<RecordValue> eValue = kvstore->getKV(mk, txn);
+  if (!eValue.ok()) {
+    if (eValue.status().code() == ErrorCodes::ERR_NOTFOUND) {
+      return {ErrorCodes::ERR_OK, ""};
     }
-    RecordType valueType = eValue.value().getRecordType();
-    auto cnt = rcd_util::getSubKeyCount(mk, eValue.value());
-    if (!cnt.ok()) {
-      return cnt.status();
-    }
+    return eValue.status();
+  }
 
-    if (useDeleteRange(cnt.value(), valueType, server->getParams())) {
-      LOG(INFO) << "bigkey delete:" << hexlify(mk.getPrimaryKey())
-                << ",rcdType:" << rt2Char(valueType) << ",size:" << cnt.value();
-      return Command::delKeyPessimisticInLock(
-        sess, storeId, mk, valueType, eValue.value());
-    } else {
-      Status s = Command::delKeyOptimismInLock(
-        sess, storeId, mk, valueType, txn, eValue.value());
-      if (s.code() == ErrorCodes::ERR_COMMIT_RETRY && i != RETRY_CNT - 1) {
-        continue;
-      }
+  return Command::delKeyInLock(sess, storeId, kvstore, mk, eValue.value(), txn);
+}
+
+// Unified delete key core logic. Requirement: LOCK_X already held.
+// txn == nullptr: creates own txn, commits internally.
+// txn != nullptr: uses caller's txn, does NOT commit (caller commits).
+// NOTE: big key always goes through delKeyPessimisticInLock which creates
+//       its own txn and commits internally regardless of the txn parameter.
+Status Command::delKeyInLock(Session* sess,
+                             uint32_t storeId,
+                             PStore kvstore,
+                             const RecordKey& mk,
+                             const RecordValue& eValue,
+                             Transaction* txn) {
+  auto server = sess->getServerEntry();
+  RecordType valueType = eValue.getRecordType();
+
+  auto cnt = rcd_util::getSubKeyCount(mk, eValue);
+  if (!cnt.ok()) {
+    return cnt.status();
+  }
+
+  // big key → pessimistic delete (always creates own txn + commits internally)
+  if (useDeleteRange(cnt.value(), valueType, server->getParams())) {
+    LOG(INFO) << "bigkey delete:" << hexlify(mk.getPrimaryKey())
+              << ",rcdType:" << rt2Char(valueType) << ",size:" << cnt.value();
+    return Command::delKeyPessimisticInLock(
+      sess, storeId, mk, valueType, eValue);
+  }
+
+  // small key: caller's txn → single attempt, no commit
+  if (txn != nullptr) {
+    return Command::delKeyOptimismInLock(
+      sess, storeId, mk, valueType, txn, eValue);
+  }
+
+  // small key: own txn → create + retry + commit
+  for (uint32_t i = 0; i < RETRY_CNT; ++i) {
+    auto ptxn = kvstore->createTransaction(sess);
+    if (!ptxn.ok()) {
+      return ptxn.status();
+    }
+    auto txnGuard = std::move(ptxn.value());
+
+    Status s = Command::delKeyOptimismInLock(
+      sess, storeId, mk, valueType, txnGuard.get(), eValue);
+    if (s.code() == ErrorCodes::ERR_COMMIT_RETRY && i != RETRY_CNT - 1) {
+      continue;
+    }
+    if (!s.ok()) {
       return s;
     }
+    return txnGuard->commit().status();
   }
   // should never reach here
   INVARIANT_D(0);
   return {ErrorCodes::ERR_INTERNAL, "not reachable"};
 }
 
+// NOTE(shianwu): Unified expire check.
+//   - LOCK_X (write path): synchronous delete
+//   - LOCK_S (read path): check TTL + submit async delete task
 // NOTE(takenliu) txn is committed in this function.
 Expected<RecordValue> Command::expireKeyIfNeeded(Session* sess,
                                                  const std::string& key,
                                                  RecordType tp,
-                                                 bool hasVersion) {
+                                                 mgl::LockMode mode) {
   auto server = sess->getServerEntry();
   INVARIANT(server != nullptr);
-  auto expdb = server->getSegmentMgr()->getDbWithKeyLock(sess, key, RdLock());
+
+  auto expdb = server->getSegmentMgr()->getDbWithKeyLock(sess, key, mode);
   if (!expdb.ok()) {
     return expdb.status();
   }
   uint32_t storeId = expdb.value().dbId;
-
-  // NOTE(wayenchen) change session args to store a del command in session
-  LocalSessionGuard sg(server, sess);
-  if (sess->getArgs().size() >= 2) {
-    sg.getSession()->setArgs({"del", key});
-  }
-
   RecordKey mk(expdb.value().chunkId, sess->getCtx()->getDbId(), tp, key, "");
   PStore kvstore = expdb.value().store;
 
-  // NOTE(takenliu) we need setReplOnly
-  sg.getSession()->getCtx()->setReplOnly(kvstore->getMode() ==
-                                         KVStore::StoreMode::REPLICATE_ONLY);
-
-  for (uint32_t i = 0; i < RETRY_CNT; ++i) {
-    // NOTE(takenliu) expireKeyIfNeeded don't use txn from params,
-    //   because it need rewrite codes too much.
-    //   so, we need new txn and commit txn in this function,
-    //   and then, we can't use sess->createTransaction
-    auto ptxn = kvstore->createTransaction(sg.getSession());
-    if (!ptxn.ok()) {
-      return ptxn.status();
-    }
-    std::unique_ptr<Transaction> txn = std::move(ptxn.value());
-    Expected<RecordValue> eValue = kvstore->getKV(mk, txn.get());
-    if (!eValue.ok()) {
-      // maybe ErrorCodes::ERR_NOTFOUND
-      ++sess->getServerEntry()->getServerStat().keyspaceMisses;
-      return eValue.status();
-    }
-
-    uint64_t currentTs = msSinceEpoch();
-    uint64_t targetTtl = eValue.value().getTtl();
-    RecordType valueType = eValue.value().getRecordType();
-    if (server->getParams()->noexpire || targetTtl == 0 ||
-        currentTs < targetTtl) {
-      if (valueType != tp && tp != RecordType::RT_DATA_META) {
-        /** NOTE(vinchen): This error message contains the key name, it is
-         * useful for users. The error message is a little different with redis.
-         * Maybe it is ok.
-         */
-        return {ErrorCodes::ERR_WRONG_TYPE,
-                "-WRONGTYPE Operation against a key holding the wrong kind of "
-                "value(" +
-                  key + ")\r\n"};
-      }
-      if (hasVersion) {
-        auto pCtx = sess->getCtx();
-        if (!pCtx->verifyVersion(eValue.value().getVersionEP())) {
-          ++sess->getServerEntry()->getServerStat().keyspaceIncorrectEp;
-          return {ErrorCodes::ERR_WRONG_VERSION_EP, ""};
-        }
-      }
-      ++sess->getServerEntry()->getServerStat().keyspaceHits;
-      return eValue.value();
-    } else if (txn->isReplOnly()) {
-      // NOTE(vinchen): if replOnly, it can't delete record, but return
-      // ErrorCodes::ERR_EXPIRED
-      return {ErrorCodes::ERR_EXPIRED, ""};
-    }
-    auto cnt = rcd_util::getSubKeyCount(mk, eValue.value());
-    if (!cnt.ok()) {
-      return cnt.status();
-    }
-
-    if (useDeleteRange(cnt.value(), valueType, server->getParams())) {
-      LOG(INFO) << "bigkey delete:" << hexlify(mk.getPrimaryKey())
-                << ",rcdType:" << rt2Char(valueType) << ",size:" << cnt.value();
-      Status s = Command::delKeyPessimisticInLock(
-        sg.getSession(), storeId, mk, valueType, eValue.value());
-      if (s.ok()) {
-        return {ErrorCodes::ERR_EXPIRED, ""};
-      } else {
-        return s;
-      }
-    } else {
-      Status s = Command::delKeyOptimismInLock(
-        sg.getSession(), storeId, mk, valueType, txn.get(), eValue.value());
-      if (!s.ok()) {
-        return s;
-      }
-      auto eCmt = txn.get()->commit();
-      if (!eCmt.ok()) {
-        return eCmt.status();
-      }
-      return {ErrorCodes::ERR_EXPIRED, ""};
-    }
+  // Read meta and check TTL
+  // Use the original sess. No LocalSessionGuard needed here.
+  auto ptxn = kvstore->createTransaction(sess);
+  if (!ptxn.ok()) {
+    return ptxn.status();
   }
-  // should never reach here
-  INVARIANT_D(0);
-  return {ErrorCodes::ERR_INTERNAL, "not reachable"};
+  std::unique_ptr<Transaction> txn = std::move(ptxn.value());
+  Expected<RecordValue> eValue = kvstore->getKV(mk, txn.get());
+  if (!eValue.ok()) {
+    ++server->getServerStat().keyspaceMisses;
+    return eValue.status();
+  }
+
+  RecordType valueType = eValue.value().getRecordType();
+  uint64_t targetTtl = eValue.value().getTtl();
+
+  // key NOT expired
+  if (server->getParams()->noexpire || targetTtl == 0 ||
+      msSinceEpoch() < targetTtl) {
+    if (valueType != tp && tp != RecordType::RT_DATA_META) {
+      return {ErrorCodes::ERR_WRONG_TYPE,
+              "-WRONGTYPE Operation against a key holding the wrong kind of "
+              "value(" +
+                key + ")\r\n"};
+    }
+    // EP version check: only when client has extended protocol enabled
+    if (sess->getCtx()->isEp() &&
+        !sess->getCtx()->verifyVersion(eValue.value().getVersionEP())) {
+      ++server->getServerStat().keyspaceIncorrectEp;
+      return {ErrorCodes::ERR_WRONG_VERSION_EP, ""};
+    }
+    ++server->getServerStat().keyspaceHits;
+    return eValue.value();
+  }
+
+  // key IS expired
+  // slave: can't delete, just report expired
+  if (txn->isReplOnly()) {
+    return {ErrorCodes::ERR_EXPIRED, ""};
+  }
+
+  // LOCK_S: no deletion, just report expired.
+  // Actual cleanup is done by IndexManager's scanExpiredKeysJob.
+  if (mode != mgl::LockMode::LOCK_X) {
+    return {ErrorCodes::ERR_EXPIRED, ""};
+  }
+
+  // LOCK_X synchronous delete
+  // Create LocalSessionGuard here (deferred from function entry).
+  // Purpose: binlog records "del" instead of the original command.
+  // NOTE: setReplOnly is NOT needed — getDbWithKeyLock already set
+  // replOnly on sess, and slave path returned early above.
+  //
+  // txn=nullptr → delKeyInLock creates own txn with delSess,
+  // so txn._session points to delSess → commit writes "del" in binlog.
+  // This is safe because LOCK_X guarantees no concurrent modification
+  // to this key, so the eValue read above is still valid.
+  LocalSessionGuard sg(server, sess);
+  sg.getSession()->setArgs({"del", key});
+  Session* delSess = sg.getSession();
+
+  // nullptr delKeyInLock creates own txn + commits internally
+  Status s = Command::delKeyInLock(
+    delSess, storeId, kvstore, mk, eValue.value(), nullptr);
+  return s.ok() ? Expected<RecordValue>{ErrorCodes::ERR_EXPIRED, ""}
+                : Expected<RecordValue>{s};
 }
 
 std::string Command::fmtErr(const std::string& s) {

--- a/src/tendisplus/commands/command.h
+++ b/src/tendisplus/commands/command.h
@@ -66,6 +66,8 @@ class Command {
   bool isWriteable() const;
   bool isAdmin() const;
   static mgl::LockMode RdLock();
+  // controlled by config param "concurrentRead"
+  static mgl::LockMode _expRdLk;
   static void changeCommand(const std::string& renameCmdList, std::string mode);
   int getFlags() const;
   size_t getFlagsCount() const;
@@ -82,10 +84,12 @@ class Command {
   // return ERR_OK if not expired
   // return ERR_EXPIRED if expired
   // return errors on other unexpected conditions
-  static Expected<RecordValue> expireKeyIfNeeded(Session* sess,
-                                                 const std::string& key,
-                                                 RecordType tp,
-                                                 bool hasVersion = true);
+  // Unified version: LOCK_X → sync delete, LOCK_S → async or lazy expire
+  static Expected<RecordValue> expireKeyIfNeeded(
+    Session* sess,
+    const std::string& key,
+    RecordType tp,
+    mgl::LockMode mode = mgl::LockMode::LOCK_X);
 
   static Expected<std::pair<std::string, std::list<Record>>> scan(
     Session* sess,
@@ -107,6 +111,19 @@ class Command {
                              const RecordValue& val,
                              PStore kvstore,
                              Transaction* txn);
+
+  // Unified delete key under LOCK_X (already held by caller).
+  // txn == nullptr: creates own txn internally, commits before return.
+  // txn != nullptr: uses caller's txn, does NOT commit (caller commits).
+  static Status delKeyInLock(Session* sess,
+                             uint32_t storeId,
+                             PStore kvstore,
+                             const RecordKey& mk,
+                             const RecordValue& eValue,
+                             Transaction* txn = nullptr);
+
+  // Acquires LOCK_X, reads meta, delegates to delKeyInLock.
+  // Not committed, caller need commit itself.
   static Status delKey(Session* sess,
                        const std::string& key,
                        RecordType tp,
@@ -146,8 +163,6 @@ class Command {
   // protected by mutex
   static const uint32_t _maxUnseenCmdNum = 10000;
   static std::map<std::string, uint64_t> _unSeenCmds;
-
-  static mgl::LockMode _expRdLk;
 
  private:
   static Status delKeyPessimisticInLock(Session* sess,

--- a/src/tendisplus/commands/debug.cpp
+++ b/src/tendisplus/commands/debug.cpp
@@ -2996,8 +2996,8 @@ class ObjectCommand : public Command {
         {RecordType::RT_ZSET_META, "skiplist"},
       };
 
-      Expected<RecordValue> rv =
-        Command::expireKeyIfNeeded(sess, key, RecordType::RT_DATA_META);
+      Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+        sess, key, RecordType::RT_DATA_META, Command::RdLock());
       if (rv.status().code() == ErrorCodes::ERR_EXPIRED ||
           rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
         return Command::fmtNull();

--- a/src/tendisplus/commands/dump.cpp
+++ b/src/tendisplus/commands/dump.cpp
@@ -704,8 +704,8 @@ class TBitmapSerializer : public Serializer {
 // outlier function
 Expected<std::unique_ptr<Serializer>> getSerializer(Session* sess,
                                                     const std::string& key) {
-  Expected<RecordValue> rv =
-    Command::expireKeyIfNeeded(sess, key, RecordType::RT_DATA_META);
+  Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+    sess, key, RecordType::RT_DATA_META, Command::RdLock());
   if (!rv.ok()) {
     return rv.status();
   }
@@ -1866,15 +1866,16 @@ class RestoreValueCommand : public Command {
   Expected<std::string> run(Session* sess) final {
     auto& key = (sess->getArgs()[1]);
     auto server = sess->getServerEntry();
-    auto expdb = server->getSegmentMgr()->getDbWithKeyLock(sess, key, RdLock());
+    auto expdb =
+      server->getSegmentMgr()->getDbWithKeyLock(sess, key, Command::RdLock());
     RET_IF_ERR_EXPECTED(expdb);
     auto slotId = expdb.value().chunkId;
 
     SessionCtx* pCtx = sess->getCtx();
     INVARIANT(pCtx != nullptr);
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_DATA_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_DATA_META, Command::RdLock());
     RET_IF_ERR_EXPECTED(rv);
 
     if (rv.value().getRecordType() == RecordType::RT_TBITMAP_META) {

--- a/src/tendisplus/commands/expire.cpp
+++ b/src/tendisplus/commands/expire.cpp
@@ -215,7 +215,8 @@ class GenericTtlCommand : public Command {
     const std::string& key = sess->getArgs()[1];
 
     for (auto type : {RecordType::RT_DATA_META}) {
-      Expected<RecordValue> rv = Command::expireKeyIfNeeded(sess, key, type);
+      Expected<RecordValue> rv =
+        Command::expireKeyIfNeeded(sess, key, type, Command::RdLock());
       if (rv.status().code() == ErrorCodes::ERR_EXPIRED) {
         continue;
       } else if (rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
@@ -320,8 +321,8 @@ class ExistsCommand : public Command {
     for (size_t j = 1; j < args.size(); j++) {
       const std::string& key = args[j];
 
-      Expected<RecordValue> rv =
-        Command::expireKeyIfNeeded(sess, key, RecordType::RT_DATA_META);
+      Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+        sess, key, RecordType::RT_DATA_META, Command::RdLock());
       if (rv.status().code() == ErrorCodes::ERR_EXPIRED) {
         continue;
       } else if (rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
@@ -374,8 +375,8 @@ class TypeCommand : public Command {
       return expdb.status();
     }
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_DATA_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_DATA_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED ||
         rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
       return Command::fmtStatus("none");

--- a/src/tendisplus/commands/hash.cpp
+++ b/src/tendisplus/commands/hash.cpp
@@ -186,8 +186,8 @@ class HLenCommand : public Command {
     SessionCtx* pCtx = sess->getCtx();
     INVARIANT(pCtx != nullptr);
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_HASH_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_HASH_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED) {
       return fmtZero();
     } else if (rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
@@ -245,7 +245,8 @@ class SizeGeneric : public Command {
     SessionCtx* pCtx = sess->getCtx();
     INVARIANT(pCtx != nullptr);
 
-    Expected<RecordValue> rv = Command::expireKeyIfNeeded(sess, key, metaType);
+    Expected<RecordValue> rv =
+      Command::expireKeyIfNeeded(sess, key, metaType, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED) {
       return fmtZero();
     } else if (rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
@@ -363,8 +364,8 @@ class HExistsCommand : public Command {
       return expdb.status();
     }
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_HASH_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_HASH_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED) {
       return Command::fmtZero();
     } else if (rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
@@ -430,8 +431,8 @@ class HAllCommand : public Command {
       return expdb.status();
     }
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_HASH_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_HASH_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED) {
       return std::list<Record>();
     } else if (rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
@@ -584,8 +585,8 @@ class HGetRecordCommand : public Command {
       return expdb.status();
     }
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_HASH_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_HASH_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED) {
       return rv.status();
     } else if (rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
@@ -876,8 +877,8 @@ class HMGetGeneric : public Command {
       return expdb.status();
     }
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_HASH_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_HASH_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_NOTFOUND ||
         rv.status().code() == ErrorCodes::ERR_EXPIRED) {
       std::stringstream ss;
@@ -964,7 +965,7 @@ Status hmcas(Session* sess,
 
   auto server = sess->getServerEntry();
   auto expdb =
-    server->getSegmentMgr()->getDbWithKeyLock(sess, key, Command::RdLock());
+    server->getSegmentMgr()->getDbWithKeyLock(sess, key, mgl::LockMode::LOCK_X);
   if (!expdb.ok()) {
     return expdb.status();
   }

--- a/src/tendisplus/commands/kv.cpp
+++ b/src/tendisplus/commands/kv.cpp
@@ -552,8 +552,8 @@ class StrlenCommand : public Command {
     SessionCtx* pCtx = sess->getCtx();
     INVARIANT(pCtx != nullptr);
     const std::string& key = sess->getArgs()[1];
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_KV);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_KV, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED) {
       return Command::fmtZero();
     } else if (rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
@@ -600,8 +600,8 @@ class BitPosCommand : public Command {
     } else {
       return {ErrorCodes::ERR_PARSEOPT, "The bit argument must be 1 or 0."};
     }
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_KV);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_KV, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED ||
         rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
       /* If the key does not exist, from our point of view it is an
@@ -694,8 +694,8 @@ class BitCountCommand : public Command {
     SessionCtx* pCtx = sess->getCtx();
     INVARIANT(pCtx != nullptr);
     const std::string& key = sess->getArgs()[1];
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_KV);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_KV, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED) {
       return Command::fmtZero();
     } else if (rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
@@ -755,8 +755,8 @@ class GetGenericCmd : public Command {
     SessionCtx* pCtx = sess->getCtx();
     INVARIANT(pCtx != nullptr);
     const std::string& key = sess->getArgs()[1];
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_KV);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_KV, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED ||
         rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
       return rv.status();
@@ -792,8 +792,8 @@ class GetVsnCommand : public Command {
     SessionCtx* pCtx = sess->getCtx();
     INVARIANT(pCtx != nullptr);
     const std::string& key = sess->getArgs()[1];
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_KV);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_KV, Command::RdLock());
 
     std::stringstream ss;
     Command::fmtMultiBulkLen(ss, 2);
@@ -1727,8 +1727,8 @@ class MGetCommand : public Command {
     Command::fmtMultiBulkLen(ss, sess->getArgs().size() - 1);
     for (size_t i = 1; i < sess->getArgs().size(); ++i) {
       const std::string& key = sess->getArgs()[i];
-      Expected<RecordValue> rv =
-        Command::expireKeyIfNeeded(sess, key, RecordType::RT_KV);
+      Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+        sess, key, RecordType::RT_KV, Command::RdLock());
       if (rv.status().code() == ErrorCodes::ERR_EXPIRED ||
           rv.status().code() == ErrorCodes::ERR_NOTFOUND ||
           rv.status().code() == ErrorCodes::ERR_WRONG_TYPE) {
@@ -2600,10 +2600,10 @@ class BitFieldCommand : public Command {
     const std::string& key = args[1];
     auto server = sess->getServerEntry();
     auto pCtx = sess->getCtx();
-    auto expdb = server->getSegmentMgr()->getDbWithKeyLock(
-      sess, key, readonly ? RdLock() : mgl::LockMode::LOCK_X);
+    auto lockMode = readonly ? Command::RdLock() : mgl::LockMode::LOCK_X;
+    auto expdb = server->getSegmentMgr()->getDbWithKeyLock(sess, key, lockMode);
     Expected<RecordValue> eRv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_KV);
+      Command::expireKeyIfNeeded(sess, key, RecordType::RT_KV, lockMode);
     if (eRv.status().code() == ErrorCodes::ERR_EXPIRED ||
         eRv.status().code() == ErrorCodes::ERR_NOTFOUND) {
       // do nothing

--- a/src/tendisplus/commands/list.cpp
+++ b/src/tendisplus/commands/list.cpp
@@ -179,8 +179,8 @@ class LLenCommand : public Command {
     SessionCtx* pCtx = sess->getCtx();
     INVARIANT(pCtx != nullptr);
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_LIST_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_LIST_META, Command::RdLock());
 
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED) {
       return fmtZero();
@@ -793,8 +793,8 @@ class LRangeCommand : public Command {
       return expdb.status();
     }
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_LIST_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_LIST_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED) {
       return fmtZeroBulkLen();
     } else if (rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
@@ -905,8 +905,8 @@ class LIndexCommand : public Command {
       return expdb.status();
     }
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_LIST_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_LIST_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED) {
       return fmtNull();
     } else if (rv.status().code() == ErrorCodes::ERR_NOTFOUND) {

--- a/src/tendisplus/commands/pf.cpp
+++ b/src/tendisplus/commands/pf.cpp
@@ -472,7 +472,8 @@ class PfCountCommand : public Command {
 
       for (size_t j = 1; j < args.size(); j++) {
         auto& key = args[j];
-        auto rv = Command::expireKeyIfNeeded(sess, key, RecordType::RT_KV);
+        auto rv = Command::expireKeyIfNeeded(
+          sess, key, RecordType::RT_KV, Command::RdLock());
         if (rv.status().code() != ErrorCodes::ERR_OK &&
             rv.status().code() != ErrorCodes::ERR_EXPIRED &&
             rv.status().code() != ErrorCodes::ERR_NOTFOUND) {
@@ -506,7 +507,8 @@ class PfCountCommand : public Command {
      * The user specified a single key. Either return the cached value
      * or compute one and update the cache. */
     const std::string& key = args[1];
-    auto rv = Command::expireKeyIfNeeded(sess, key, RecordType::RT_KV);
+    auto rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_KV, Command::RdLock());
     if (rv.status().code() != ErrorCodes::ERR_OK &&
         rv.status().code() != ErrorCodes::ERR_EXPIRED &&
         rv.status().code() != ErrorCodes::ERR_NOTFOUND) {

--- a/src/tendisplus/commands/scan.cpp
+++ b/src/tendisplus/commands/scan.cpp
@@ -85,11 +85,12 @@ class ScanGenericCommand : public Command {
     }
 
     auto server = sess->getServerEntry();
-    auto expdb = server->getSegmentMgr()->getDbWithKeyLock(sess, key, RdLock());
+    auto expdb =
+      server->getSegmentMgr()->getDbWithKeyLock(sess, key, Command::RdLock());
     RET_IF_ERR_EXPECTED(expdb);
 
     Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, getRcdType());
+      Command::expireKeyIfNeeded(sess, key, getRcdType(), Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED ||
         rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
       std::stringstream ss;

--- a/src/tendisplus/commands/set.cpp
+++ b/src/tendisplus/commands/set.cpp
@@ -252,8 +252,8 @@ class SMembersCommand : public Command {
       return expdb.status();
     }
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_SET_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_SET_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED) {
       return Command::fmtZeroBulkLen();
     } else if (rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
@@ -350,8 +350,8 @@ class SIsMemberCommand : public Command {
       return expdb.status();
     }
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_SET_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_SET_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED) {
       return fmtZero();
     } else if (rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
@@ -438,8 +438,8 @@ class SrandMemberCommand : public Command {
     auto expdb =
       server->getSegmentMgr()->getDbWithKeyLock(sess, key, Command::RdLock());
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_SET_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_SET_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED ||
         rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
       if (bulk == 1 && !explictBulk) {
@@ -822,8 +822,8 @@ class ScardCommand : public Command {
     SessionCtx* pCtx = sess->getCtx();
     INVARIANT(pCtx != nullptr);
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_SET_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_SET_META, Command::RdLock());
 
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED) {
       return fmtZero();
@@ -935,15 +935,16 @@ class SdiffgenericCommand : public Command {
     SessionCtx* pCtx = sess->getCtx();
 
     std::vector<int> index = getKeysFromCommand(args);
-    auto lock = server->getSegmentMgr()->getAllKeysLocked(
-      sess, args, index, _store ? mgl::LockMode::LOCK_X : Command::RdLock());
+    auto lockMode = _store ? mgl::LockMode::LOCK_X : Command::RdLock();
+    auto lock =
+      server->getSegmentMgr()->getAllKeysLocked(sess, args, index, lockMode);
     if (!lock.ok()) {
       return lock.status();
     }
 
     for (size_t i = startkey; i < args.size(); ++i) {
-      Expected<RecordValue> rv =
-        Command::expireKeyIfNeeded(sess, args[i], RecordType::RT_SET_META);
+      Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+        sess, args[i], RecordType::RT_SET_META, lockMode);
       if (rv.status().code() == ErrorCodes::ERR_EXPIRED) {
         continue;
       } else if (rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
@@ -1127,8 +1128,9 @@ class SintergenericCommand : public Command {
     SessionCtx* pCtx = sess->getCtx();
 
     std::vector<int> index = getKeysFromCommand(args);
-    auto lock = server->getSegmentMgr()->getAllKeysLocked(
-      sess, args, index, _store ? mgl::LockMode::LOCK_X : Command::RdLock());
+    auto lockMode = _store ? mgl::LockMode::LOCK_X : Command::RdLock();
+    auto lock =
+      server->getSegmentMgr()->getAllKeysLocked(sess, args, index, lockMode);
     if (!lock.ok()) {
       return lock.status();
     }
@@ -1136,8 +1138,8 @@ class SintergenericCommand : public Command {
     // stored all sets sorted by their length
     std::vector<std::pair<size_t, uint64_t>> setList;
     for (size_t i = startkey; i < args.size(); i++) {
-      Expected<RecordValue> rv =
-        Command::expireKeyIfNeeded(sess, args[i], RecordType::RT_SET_META);
+      Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+        sess, args[i], RecordType::RT_SET_META, lockMode);
 
       // if one set is empty, their intersection is empty set, so just
       // return it.
@@ -1187,8 +1189,8 @@ class SintergenericCommand : public Command {
         std::string prefix = fakeRk.prefixPk();
 
         std::string seekPos = "";
-        Expected<RecordValue> rv =
-          Command::expireKeyIfNeeded(sess, args[i], RecordType::RT_SET_META);
+        Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+          sess, args[i], RecordType::RT_SET_META, lockMode);
         if (rv.ok()) {
           Expected<SetMetaValue> exptSm =
             SetMetaValue::decode(rv.value().getValue());
@@ -1512,15 +1514,16 @@ class SuniongenericCommand : public Command {
     SessionCtx* pCtx = sess->getCtx();
 
     std::vector<int> index = getKeysFromCommand(args);
-    auto lock = server->getSegmentMgr()->getAllKeysLocked(
-      sess, args, index, _store ? mgl::LockMode::LOCK_X : Command::RdLock());
+    auto lockMode = _store ? mgl::LockMode::LOCK_X : Command::RdLock();
+    auto lock =
+      server->getSegmentMgr()->getAllKeysLocked(sess, args, index, lockMode);
     if (!lock.ok()) {
       return lock.status();
     }
 
     for (size_t i = startkey; i < args.size(); ++i) {
-      Expected<RecordValue> rv =
-        Command::expireKeyIfNeeded(sess, args[i], RecordType::RT_SET_META);
+      Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+        sess, args[i], RecordType::RT_SET_META, lockMode);
       if (rv.status().code() == ErrorCodes::ERR_EXPIRED ||
           rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
         continue;

--- a/src/tendisplus/commands/sort.cpp
+++ b/src/tendisplus/commands/sort.cpp
@@ -82,8 +82,8 @@ class SortCommand : public Command {
       return expdb.status();
     }
 
-    auto byRv =
-      Command::expireKeyIfNeeded(sess, metaKey, RecordType::RT_DATA_META);
+    auto byRv = Command::expireKeyIfNeeded(
+      sess, metaKey, RecordType::RT_DATA_META, Command::RdLock());
     // should handle NOT_FOUND and EXPIRED outsie
     if (!byRv.ok()) {
       return byRv.status();
@@ -250,8 +250,11 @@ class SortCommand : public Command {
     PStore kvstore = expdb.value().store;
 
     /* 3. Get the sort key and length */
-    auto expRv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_DATA_META);
+    auto expRv = Command::expireKeyIfNeeded(sess,
+                                            key,
+                                            RecordType::RT_DATA_META,
+                                            store ? mgl::LockMode::LOCK_X
+                                                  : Command::RdLock());
     if (expRv.status().code() == ErrorCodes::ERR_EXPIRED ||
         expRv.status().code() == ErrorCodes::ERR_NOTFOUND) {
       exist = false;

--- a/src/tendisplus/commands/tbitmap.cpp
+++ b/src/tendisplus/commands/tbitmap.cpp
@@ -422,15 +422,15 @@ class TGetBitCommand : public Command {
     auto pctx = sess->getCtx();
     INVARIANT(pctx != nullptr);
     auto edb = sess->getServerEntry()->getSegmentMgr()->getDbWithKeyLock(
-      sess, key, RdLock());
+      sess, key, Command::RdLock());
     RET_IF_ERR_EXPECTED(edb);
     auto kvstore = edb.value().store;
     auto eptxn = pctx->createTransaction(kvstore);
     RET_IF_ERR_EXPECTED(eptxn);
 
     // mainly for meta data
-    auto emetaRv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_TBITMAP_META);
+    auto emetaRv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_TBITMAP_META, Command::RdLock());
     if (emetaRv.status().code() == ErrorCodes::ERR_EXPIRED ||
         emetaRv.status().code() == ErrorCodes::ERR_NOTFOUND) {
       return Command::fmtZero();
@@ -520,8 +520,8 @@ class TBitCountCommand : public Command {
     RET_IF_ERR_EXPECTED(eptxn);
 
     // mainly for meta data
-    auto emetaRv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_TBITMAP_META);
+    auto emetaRv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_TBITMAP_META, Command::RdLock());
     if (emetaRv.status().code() == ErrorCodes::ERR_EXPIRED ||
         emetaRv.status().code() == ErrorCodes::ERR_NOTFOUND) {
       return Command::fmtZero();
@@ -661,8 +661,8 @@ class TBitPosCommand : public Command {
     RET_IF_ERR_EXPECTED(eptxn);
 
     // mainly for meta data
-    auto emetaRv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_TBITMAP_META);
+    auto emetaRv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_TBITMAP_META, Command::RdLock());
     if (emetaRv.status().code() == ErrorCodes::ERR_EXPIRED ||
         emetaRv.status().code() == ErrorCodes::ERR_NOTFOUND) {
       return bit ? Command::fmtLongLong(-1) : Command::fmtZero();
@@ -1162,8 +1162,9 @@ class TBitFieldCommand : public Command {
 
     auto pctx = sess->getCtx();
     INVARIANT(pctx != nullptr);
+    auto lockMode = readonly ? Command::RdLock() : mgl::LockMode::LOCK_X;
     auto edb = sess->getServerEntry()->getSegmentMgr()->getDbWithKeyLock(
-      sess, (key), readonly ? RdLock() : mgl::LockMode::LOCK_X);
+      sess, (key), lockMode);
     RET_IF_ERR_EXPECTED(edb);
     auto kvstore = edb.value().store;
     auto eptxn = pctx->createTransaction(kvstore);
@@ -1173,8 +1174,8 @@ class TBitFieldCommand : public Command {
 
     bool metaExists = true;
 
-    auto emetaRv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_TBITMAP_META);
+    auto emetaRv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_TBITMAP_META, lockMode);
     uint64_t fragmentLen =
       sess->getServerEntry()->getParams()->tbitmapFragmentSize;
     TBitMapMetaValue meta(fragmentLen);

--- a/src/tendisplus/commands/zset.cpp
+++ b/src/tendisplus/commands/zset.cpp
@@ -644,8 +644,8 @@ class ZCardCommand : public Command {
     const std::vector<std::string>& args = sess->getArgs();
     const std::string& key = args[1];
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_ZSET_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_ZSET_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED ||
         rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
       return Command::fmtZero();
@@ -693,8 +693,8 @@ class ZRankCommand : public Command {
     if (!expdb.ok()) {
       return expdb.status();
     }
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_ZSET_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_ZSET_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED ||
         rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
       return Command::fmtNull();
@@ -741,13 +741,14 @@ class ZRevRankCommand : public Command {
     const std::string& subkey = args[2];
 
     auto server = sess->getServerEntry();
-    auto expdb = server->getSegmentMgr()->getDbWithKeyLock(sess, key, RdLock());
+    auto expdb =
+      server->getSegmentMgr()->getDbWithKeyLock(sess, key, Command::RdLock());
     if (!expdb.ok()) {
       return expdb.status();
     }
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_ZSET_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_ZSET_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED ||
         rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
       return Command::fmtNull();
@@ -885,8 +886,8 @@ class ZCountCommand : public Command {
       return expdb.status();
     }
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_ZSET_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_ZSET_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED ||
         rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
       return Command::fmtZero();
@@ -975,8 +976,8 @@ class ZlexCountCommand : public Command {
       return expdb.status();
     }
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_ZSET_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_ZSET_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED ||
         rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
       return Command::fmtZero();
@@ -1110,8 +1111,8 @@ class ZRangeByScoreGenericCommand : public Command {
       return expdb.status();
     }
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_ZSET_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_ZSET_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED ||
         rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
       return Command::fmtZeroBulkLen();
@@ -1243,8 +1244,8 @@ class ZRangeByLexGenericCommand : public Command {
       return expdb.status();
     }
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_ZSET_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_ZSET_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED ||
         rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
       return Command::fmtZeroBulkLen();
@@ -1344,8 +1345,8 @@ class ZRangeGenericCommand : public Command {
       return expdb.status();
     }
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_ZSET_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_ZSET_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED ||
         rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
       return Command::fmtZeroBulkLen();
@@ -1448,8 +1449,8 @@ class ZScoreCommand : public Command {
       return expdb.status();
     }
 
-    Expected<RecordValue> rv =
-      Command::expireKeyIfNeeded(sess, key, RecordType::RT_ZSET_META);
+    Expected<RecordValue> rv = Command::expireKeyIfNeeded(
+      sess, key, RecordType::RT_ZSET_META, Command::RdLock());
     if (rv.status().code() == ErrorCodes::ERR_EXPIRED ||
         rv.status().code() == ErrorCodes::ERR_NOTFOUND) {
       return Command::fmtNull();

--- a/src/tendisplus/server/repl_test.cpp
+++ b/src/tendisplus/server/repl_test.cpp
@@ -14,12 +14,9 @@
 
 #include "tendisplus/commands/command.h"
 #include "tendisplus/network/network.h"
-#include "tendisplus/server/index_manager.h"
-#include "tendisplus/server/segment_manager.h"
 #include "tendisplus/server/server_entry.h"
 #include "tendisplus/utils/invariant.h"
 #include "tendisplus/utils/scopeguard.h"
-#include "tendisplus/utils/sync_point.h"
 #include "tendisplus/utils/test_util.h"
 
 namespace tendisplus {
@@ -537,10 +534,17 @@ INSTANTIATE_TEST_CASE_P(BinlogDisabledTest,
                         MasterBinlogDisabledTest,
                         testing::Bool());
 
+// Original test: concurrentRead=false (LOCK_X path).
+// Master GET triggers synchronous delete → produces del binlog.
 void testSlaveDontDeleteExpiredKey(std::shared_ptr<NetSession> sessionMaster,
                                    std::shared_ptr<NetSession> sessionSlave) {
-  sessionMaster->setArgs({"setex", "a", "2", "3"});
+  // Disable concurrentRead so GET uses LOCK_X (original behavior)
+  sessionMaster->setArgs({"config", "set", "concurrentRead", "false"});
   auto expect = Command::runSessionCmd(sessionMaster.get());
+  EXPECT_TRUE(expect.ok());
+
+  sessionMaster->setArgs({"setex", "a", "2", "3"});
+  expect = Command::runSessionCmd(sessionMaster.get());
   EXPECT_TRUE(expect.ok());
   sessionMaster->setArgs({"binlogpos", "5"});
   expect = Command::runSessionCmd(sessionMaster.get());
@@ -579,6 +583,173 @@ void testSlaveDontDeleteExpiredKey(std::shared_ptr<NetSession> sessionMaster,
   sessionSlave->setArgs({"binlogpos", "5"});
   expect = Command::runSessionCmd(sessionSlave.get());
   EXPECT_EQ(expect.value(), ":3\r\n");
+
+  // Restore concurrentRead to default
+  sessionMaster->setArgs({"config", "set", "concurrentRead", "true"});
+  expect = Command::runSessionCmd(sessionMaster.get());
+  EXPECT_TRUE(expect.ok());
+}
+
+// New test: concurrentRead=true (LOCK_S path).
+// Only complex types (Hash/Set/ZSet/List) create TTLIndex, so IndexManager can
+// only delete these types via TTLIndex scanning.
+void testSlaveDontDeleteExpiredKeyConcurrentRead(
+  std::shared_ptr<NetSession> sessionMaster,
+  std::shared_ptr<NetSession> sessionSlave) {
+  // Ensure concurrentRead is enabled
+  sessionMaster->setArgs({"config", "set", "concurrentRead", "true"});
+  auto expect = Command::runSessionCmd(sessionMaster.get());
+  EXPECT_TRUE(expect.ok());
+
+  // Disable IndexManager's background scan to have deterministic control
+  sessionMaster->setArgs({"config", "set", "noexpire", "yes"});
+  expect = Command::runSessionCmd(sessionMaster.get());
+  EXPECT_TRUE(expect.ok());
+
+  // Verify GET does NOT produce del binlog (String key) --
+  sessionMaster->setArgs({"setex", "a", "2", "3"});
+  expect = Command::runSessionCmd(sessionMaster.get());
+  EXPECT_TRUE(expect.ok());
+
+  // Record binlogpos after setex (before any expire-related operations)
+  sessionMaster->setArgs({"binlogpos", "5"});
+  expect = Command::runSessionCmd(sessionMaster.get());
+  EXPECT_TRUE(expect.ok());
+  std::string binlogposAfterSetex = expect.value();
+
+  sleep(4);  // Wait for key to expire (logically)
+
+  // Temporarily enable expire check for GET test only
+  sessionMaster->setArgs({"config", "set", "noexpire", "no"});
+  expect = Command::runSessionCmd(sessionMaster.get());
+  EXPECT_TRUE(expect.ok());
+
+  // Master: GET expired key (LOCK_S path)
+  sessionMaster->setArgs({"get", "a"});
+  expect = Command::runSessionCmd(sessionMaster.get());
+  // LOCK_S path: expireKeyIfNeeded checks TTL -> expired -> returns ERR_EXPIRED
+  // -> nil
+  EXPECT_EQ(expect.value(), "$-1\r\n");
+
+  // CORE ASSERTION: binlogpos must NOT change — GET with LOCK_S does not delete
+  sessionMaster->setArgs({"binlogpos", "5"});
+  expect = Command::runSessionCmd(sessionMaster.get());
+  EXPECT_EQ(expect.value(), binlogposAfterSetex);
+
+  // Immediately disable expire again to prevent IndexManager background scan
+  sessionMaster->setArgs({"config", "set", "noexpire", "yes"});
+  expect = Command::runSessionCmd(sessionMaster.get());
+  EXPECT_TRUE(expect.ok());
+
+  // Slave: same verification (slave respects master's replication, not local
+  // noexpire)
+  sessionSlave->setArgs({"binlogpos", "5"});
+  expect = Command::runSessionCmd(sessionSlave.get());
+  EXPECT_TRUE(expect.ok());
+  std::string slaveBinlogBefore = expect.value();
+
+  // For slave GET test, we need to temporarily enable expire check
+  sessionSlave->setArgs({"config", "set", "noexpire", "no"});
+  expect = Command::runSessionCmd(sessionSlave.get());
+  EXPECT_TRUE(expect.ok());
+
+  sessionSlave->setArgs({"get", "a"});
+  expect = Command::runSessionCmd(sessionSlave.get());
+  EXPECT_TRUE(expect.ok());  // nil (expired)
+
+  sessionSlave->setArgs({"binlogpos", "5"});
+  expect = Command::runSessionCmd(sessionSlave.get());
+  EXPECT_EQ(expect.value(), slaveBinlogBefore);
+
+  // Re-enable noexpire on slave
+  sessionSlave->setArgs({"config", "set", "noexpire", "yes"});
+  expect = Command::runSessionCmd(sessionSlave.get());
+  EXPECT_TRUE(expect.ok());
+
+  // Clean up String key "a" (cannot be deleted by IndexManager since no
+  // TTLIndex)
+  sessionMaster->setArgs({"config", "set", "noexpire", "no"});
+  expect = Command::runSessionCmd(sessionMaster.get());
+  EXPECT_TRUE(expect.ok());
+  sessionMaster->setArgs({"del", "a"});
+  expect = Command::runSessionCmd(sessionMaster.get());
+  // DEL returns :0 for expired key (expireKeyIfNeeded already deleted it),
+  // or :1 if it was just a logical expiration
+  EXPECT_TRUE(expect.ok());
+
+  // Wait for slave to sync the del
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+
+  // Only complex types (Hash/Set/ZSet/List) have TTLIndex, so IndexManager can
+  // only find and delete them. We use Hash key "myhash" which is also in
+  // store 5.
+  sessionMaster->setArgs({"config", "set", "noexpire", "yes"});
+  expect = Command::runSessionCmd(sessionMaster.get());
+  EXPECT_TRUE(expect.ok());
+
+  // Create a Hash key with 2-second TTL (myhash is also in store 5)
+  sessionMaster->setArgs({"hset", "myhash", "field1", "value1"});
+  expect = Command::runSessionCmd(sessionMaster.get());
+  EXPECT_TRUE(expect.ok());
+  sessionMaster->setArgs({"expire", "myhash", "2"});
+  expect = Command::runSessionCmd(sessionMaster.get());
+  EXPECT_TRUE(expect.ok());
+
+  // Record binlogpos after creating hash key
+  sessionMaster->setArgs({"binlogpos", "5"});
+  expect = Command::runSessionCmd(sessionMaster.get());
+  EXPECT_TRUE(expect.ok());
+  std::string binlogposAfterHash = expect.value();
+
+  sleep(4);  // Wait for key to expire (logically)
+
+  // Verify HGET returns nil (expired)
+  sessionMaster->setArgs({"config", "set", "noexpire", "no"});
+  expect = Command::runSessionCmd(sessionMaster.get());
+  EXPECT_TRUE(expect.ok());
+  sessionMaster->setArgs({"hget", "myhash", "field1"});
+  expect = Command::runSessionCmd(sessionMaster.get());
+  EXPECT_EQ(expect.value(), "$-1\r\n");  // nil (expired)
+
+  // Verify HGET doesn't produce del binlog (LOCK_S path)
+  sessionMaster->setArgs({"binlogpos", "5"});
+  expect = Command::runSessionCmd(sessionMaster.get());
+  EXPECT_EQ(expect.value(), binlogposAfterHash);
+
+  // Now let IndexManager's background thread handle the deletion.
+
+  // Poll until key is deleted by IndexManager's background thread
+  bool keyDeleted = false;
+  for (int retry = 0; retry < 50; ++retry) {
+    sessionMaster->setArgs({"dbsize", "containexpire"});
+    expect = Command::runSessionCmd(sessionMaster.get());
+    if (expect.value() == ":0\r\n") {
+      keyDeleted = true;
+      break;
+    }
+    // Background run() cycles every 1s. Poll every 200ms, up to 10s total.
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  }
+  EXPECT_TRUE(keyDeleted)
+    << "IndexManager failed to delete expired hash key within timeout";
+
+  sessionMaster->setArgs({"binlogpos", "5"});
+  expect = Command::runSessionCmd(sessionMaster.get());
+  // binlogpos should be incremented by del binlog from IndexManager
+  EXPECT_NE(expect.value(), binlogposAfterHash);  // Changed!
+
+  // Wait for slave to catch up
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+
+  // Verify slave: del binlog replicated
+  sessionSlave->setArgs({"dbsize", "containexpire"});
+  expect = Command::runSessionCmd(sessionSlave.get());
+  EXPECT_EQ(expect.value(), ":0\r\n");  // Replicated
+
+  // Restore default config
+  sessionMaster->setArgs({"config", "set", "concurrentRead", "true"});
+  expect = Command::runSessionCmd(sessionMaster.get());
+  EXPECT_TRUE(expect.ok());
 }
 
 TEST(Repl, SlaveCantModify) {
@@ -650,6 +821,7 @@ TEST(Repl, SlaveCantModify) {
       EXPECT_EQ(expect.value(), "$1\r\n2\r\n");
 
       testSlaveDontDeleteExpiredKey(session1, session2);
+      testSlaveDontDeleteExpiredKeyConcurrentRead(session1, session2);
     }
 
 #ifndef _WIN32

--- a/src/tendisplus/server/restore_test.cpp
+++ b/src/tendisplus/server/restore_test.cpp
@@ -139,6 +139,11 @@ void restoreBinlog(const std::string& src_binlog_dir,
 
     std::string subpath =
       "./" + src_binlog_dir + "/dump/" + std::to_string(i) + "/";
+    if (!std::filesystem::exists(subpath)) {
+      LOG(INFO) << "restoreBinlog skip store:" << i
+                << " dump dir not exists:" << subpath;
+      continue;
+    }
     std::vector<std::string> loglist;
     for (auto& p : std::filesystem::recursive_directory_iterator(subpath)) {
       const std::filesystem::path& path = p.path();
@@ -477,10 +482,26 @@ TEST(Restore, Common) {
     LOG(INFO) << ">>>>>> compareData 2st end;";
 
     testAll(master1);
+    // With concurrentRead=true, read commands use LOCK_S and don't
+    // synchronously delete expired keys. IndexManager must finish cleaning
+    // before flushBinlog, so the dump file contains the complete del binlogs
+    // for these keys.
+    std::this_thread::sleep_for(std::chrono::seconds(3));
+
+    // Pause IndexManager on master2 to prevent it from producing extra
+    // del binlogs during restoreBinlog (which would advance highestBinlogId
+    // and cause "binlogId can't be smaller than highestBinlogId" errors).
+    runCommand(master2, {"config", "set", "noexpire", "yes"});
+
     addOneKeyEveryKvstore(master1, "restore_test_key1");
     waitBinlogDump(master1);
     flushBinlog(master1);
     restoreBinlog(master1_dir, master2, UINT64_MAX);
+
+    // Restore normal expire processing
+    runCommand(master2, {"config", "set", "noexpire", "no"});
+    // Wait for IndexManager to clean up any expired keys on master2
+    std::this_thread::sleep_for(std::chrono::seconds(3));
     addOneKeyEveryKvstore(master2, "restore_test_key1");
     waitBinlogDump(master2);
     LOG(INFO) << ">>>>>> compareData 3st end;";

--- a/src/tendisplus/server/server_entry.cpp
+++ b/src/tendisplus/server/server_entry.cpp
@@ -445,6 +445,14 @@ ServerEntry::ServerEntry(const std::shared_ptr<ServerParams>& cfg)
     ->setUpdate([this]() -> Status {
       return updateCompactDeletion("rocks.compaction_deletes_ratio", _cfg);
     });
+  // concurrentRead: control whether GET commands use LOCK_S or LOCK_X
+  Command::_expRdLk =
+    _cfg->concurrentRead ? mgl::LockMode::LOCK_S : mgl::LockMode::LOCK_X;
+  _cfg->serverParamsVar("concurrentRead")->setUpdate([this]() -> Status {
+    Command::_expRdLk =
+      _cfg->concurrentRead ? mgl::LockMode::LOCK_S : mgl::LockMode::LOCK_X;
+    return {ErrorCodes::ERR_OK, ""};
+  });
 }
 
 ServerEntry::~ServerEntry() {

--- a/src/tendisplus/server/server_params.cpp
+++ b/src/tendisplus/server/server_params.cpp
@@ -373,6 +373,7 @@ ServerParams::ServerParams() {
 
   REGISTER_VARS_ALLOW_DYNAMIC_SET(noexpire);
   REGISTER_VARS_ALLOW_DYNAMIC_SET(noexpireBlob);
+  REGISTER_VARS_ALLOW_DYNAMIC_SET(concurrentRead);
   REGISTER_VARS_SAME_NAME(
     maxBinlogKeepNum, nullptr, nullptr, 1, INT64_MAX, true);
   REGISTER_VARS_ALLOW_DYNAMIC_SET(minBinlogKeepSec);

--- a/src/tendisplus/server/server_params.h
+++ b/src/tendisplus/server/server_params.h
@@ -488,6 +488,7 @@ class ServerParams {
 
   bool noexpire = false;
   bool noexpireBlob = true;
+  bool concurrentRead = true;  // GET commands use LOCK_S instead of LOCK_X
   uint64_t maxBinlogKeepNum = 1;
   uint32_t minBinlogKeepSec = 3600;
   uint64_t slaveBinlogKeepNum = 1;

--- a/src/tendisplus/utils/test_util.cpp
+++ b/src/tendisplus/utils/test_util.cpp
@@ -2902,99 +2902,101 @@ void testExpireCommandWhenNoexpireTrue(std::shared_ptr<ServerEntry> svr) {
   EXPECT_EQ(expect.value(), Command::fmtOne());
 }
 
+namespace {
+
+void cleanupExpireTestKeys(NetSession* sess) {
+  for (const auto& k : {"key", "myhash", "myset", "myzset", "mylist"}) {
+    sess->setArgs({"del", k});
+    Command::runSessionCmd(sess);
+  }
+}
+
+void buildExpiredMultiTypeKeys(NetSession* sess) {
+  auto runOkEq = [sess](const std::vector<std::string>& args,
+                        const std::string& expected) {
+    sess->setArgs(args);
+    auto expect = Command::runSessionCmd(sess);
+    EXPECT_TRUE(expect.ok());
+    EXPECT_EQ(expect.value(), expected);
+  };
+
+  runOkEq({"set", "key", "xxx", "PX", std::to_string(1)}, Command::fmtOK());
+
+  runOkEq({"hset", "myhash", "k", "v"}, Command::fmtOne());
+  runOkEq({"pexpire", "myhash", std::to_string(1)}, Command::fmtOne());
+
+  runOkEq({"sadd", "myset", "v"}, Command::fmtOne());
+  runOkEq({"pexpire", "myset", std::to_string(1)}, Command::fmtOne());
+
+  runOkEq({"zadd", "myzset", std::to_string(100), "k"}, Command::fmtOne());
+  runOkEq({"pexpire", "myzset", std::to_string(1)}, Command::fmtOne());
+
+  runOkEq({"lpush", "mylist", "v"}, Command::fmtOne());
+  runOkEq({"pexpire", "mylist", std::to_string(1)}, Command::fmtOne());
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+}
+
+void expectExpiredMultiTypeInvisible(NetSession* sess) {
+  auto run = [sess](const std::vector<std::string>& args) {
+    sess->setArgs(args);
+    auto expect = Command::runSessionCmd(sess);
+    EXPECT_TRUE(expect.ok());
+    return expect.value();
+  };
+
+  EXPECT_EQ(run({"get", "key"}), Command::fmtNull());
+  EXPECT_EQ(run({"hget", "myhash", "k"}), Command::fmtNull());
+  EXPECT_EQ(run({"smembers", "myset"}), Command::fmtZeroBulkLen());
+  EXPECT_EQ(run({"zrange", "myzset", "0", "-1"}), Command::fmtZeroBulkLen());
+  EXPECT_EQ(run({"lindex", "mylist", "0"}), Command::fmtNull());
+}
+
+void expectExpiredMultiTypeVisible(NetSession* sess) {
+  auto run = [sess](const std::vector<std::string>& args) {
+    sess->setArgs(args);
+    auto expect = Command::runSessionCmd(sess);
+    EXPECT_TRUE(expect.ok());
+    return expect.value();
+  };
+
+  EXPECT_EQ(run({"get", "key"}), Command::fmtBulk("xxx"));
+  EXPECT_EQ(run({"hget", "myhash", "k"}), Command::fmtBulk("v"));
+
+  std::stringstream ss;
+  Command::fmtMultiBulkLen(ss, 1);
+  Command::fmtBulk(ss, "v");
+  EXPECT_EQ(run({"smembers", "myset"}), ss.str());
+
+  ss.str("");
+  Command::fmtMultiBulkLen(ss, 1);
+  Command::fmtBulk(ss, "k");
+  EXPECT_EQ(run({"zrange", "myzset", "0", "-1"}), ss.str());
+
+  EXPECT_EQ(run({"lindex", "mylist", "0"}), Command::fmtBulk("v"));
+}
+
+}  // namespace
+
 void testExpireKeyWhenGet(std::shared_ptr<ServerEntry> svr) {
   asio::io_context ioContext;
   asio::ip::tcp::socket socket(ioContext), socket1(ioContext);
   NetSession sess(svr, std::move(socket), 1, false, nullptr, nullptr);
+
+  // Use LOCK_X for reads so that GET triggers synchronous delete
+  sess.setArgs({"config", "set", "concurrentRead", "false"});
+  auto expectCR = Command::runSessionCmd(&sess);
+  EXPECT_TRUE(expectCR.ok());
 
   sess.setArgs({"config", "set", "noexpire", "yes"});
   auto expect = Command::runSessionCmd(&sess);
   EXPECT_TRUE(expect.ok());
   EXPECT_EQ(expect.value(), Command::fmtOK());
 
-  // string
-  sess.setArgs({"set", "key", "xxx", "PX", std::to_string(1)});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtOK());
-
-  // hash
-  sess.setArgs({"hset", "myhash", "k", "v"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtOne());
-
-  sess.setArgs({"pexpire", "myhash", std::to_string(1)});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtOne());
-
-  // set
-  sess.setArgs({"sadd", "myset", "v"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtOne());
-
-  sess.setArgs({"pexpire", "myset", std::to_string(1)});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtOne());
-
-  // zset
-  sess.setArgs({"zadd", "myzset", std::to_string(100), "k"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtOne());
-
-  sess.setArgs({"pexpire", "myzset", std::to_string(1)});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtOne());
-
-  // list
-  sess.setArgs({"lpush", "mylist", "v"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtOne());
-
-  sess.setArgs({"pexpire", "mylist", std::to_string(1)});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtOne());
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  buildExpiredMultiTypeKeys(&sess);
 
   // we can get expired key, if noexpire true
-  sess.setArgs({"get", "key"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtBulk("xxx"));
-
-  sess.setArgs({"hget", "myhash", "k"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtBulk("v"));
-
-  sess.setArgs({"smembers", "myset"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  std::stringstream ss;
-  Command::fmtMultiBulkLen(ss, 1);
-  Command::fmtBulk(ss, "v");
-  EXPECT_EQ(expect.value(), ss.str());
-
-  sess.setArgs({"zrange", "myzset", "0", "-1"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  ss.str("");
-  Command::fmtMultiBulkLen(ss, 1);
-  Command::fmtBulk(ss, "k");
-  EXPECT_EQ(expect.value(), ss.str());
-
-  sess.setArgs({"lindex", "mylist", "0"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtBulk("v"));
+  expectExpiredMultiTypeVisible(&sess);
 
   // delete expired key when get
   sess.setArgs({"config", "set", "noexpire", "no"});
@@ -3002,30 +3004,12 @@ void testExpireKeyWhenGet(std::shared_ptr<ServerEntry> svr) {
   EXPECT_TRUE(expect.ok());
   EXPECT_EQ(expect.value(), Command::fmtOK());
 
-  sess.setArgs({"get", "key"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtNull());
+  expectExpiredMultiTypeInvisible(&sess);
 
-  sess.setArgs({"hget", "myhash", "k"});
+  // Restore concurrentRead to default
+  sess.setArgs({"config", "set", "concurrentRead", "true"});
   expect = Command::runSessionCmd(&sess);
   EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtNull());
-
-  sess.setArgs({"smembers", "myset"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtZeroBulkLen());
-
-  sess.setArgs({"zrange", "myzset", "0", "-1"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtZeroBulkLen());
-
-  sess.setArgs({"lindex", "mylist", "0"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtNull());
 }
 
 void testExpireKeyWhenCompaction(std::shared_ptr<ServerEntry> svr) {
@@ -3033,94 +3017,18 @@ void testExpireKeyWhenCompaction(std::shared_ptr<ServerEntry> svr) {
   asio::ip::tcp::socket socket(ioContext), socket1(ioContext);
   NetSession sess(svr, std::move(socket), 1, false, nullptr, nullptr);
 
+  // Explicit cleanup: ensure no stale keys from previous tests
+  cleanupExpireTestKeys(&sess);
+
   sess.setArgs({"config", "set", "noexpire", "yes"});
   auto expect = Command::runSessionCmd(&sess);
   EXPECT_TRUE(expect.ok());
   EXPECT_EQ(expect.value(), Command::fmtOK());
 
-  // string
-  sess.setArgs({"set", "key", "xxx", "PX", std::to_string(1)});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtOK());
-
-  // hash
-  sess.setArgs({"hset", "myhash", "k", "v"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtOne());
-
-  sess.setArgs({"pexpire", "myhash", std::to_string(1)});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtOne());
-
-  // set
-  sess.setArgs({"sadd", "myset", "v"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtOne());
-
-  sess.setArgs({"pexpire", "myset", std::to_string(1)});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtOne());
-
-  // zset
-  sess.setArgs({"zadd", "myzset", std::to_string(100), "k"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtOne());
-
-  sess.setArgs({"pexpire", "myzset", std::to_string(1)});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtOne());
-
-  // list
-  sess.setArgs({"lpush", "mylist", "v"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtOne());
-
-  sess.setArgs({"pexpire", "mylist", std::to_string(1)});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtOne());
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  buildExpiredMultiTypeKeys(&sess);
 
   // we can get expired key, if noexpire true
-  sess.setArgs({"get", "key"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtBulk("xxx"));
-
-  sess.setArgs({"hget", "myhash", "k"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtBulk("v"));
-
-  sess.setArgs({"smembers", "myset"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  std::stringstream ss;
-  Command::fmtMultiBulkLen(ss, 1);
-  Command::fmtBulk(ss, "v");
-  EXPECT_EQ(expect.value(), ss.str());
-
-  sess.setArgs({"zrange", "myzset", "0", "-1"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  ss.str("");
-  Command::fmtMultiBulkLen(ss, 1);
-  Command::fmtBulk(ss, "k");
-  EXPECT_EQ(expect.value(), ss.str());
-
-  sess.setArgs({"lindex", "mylist", "0"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtBulk("v"));
+  expectExpiredMultiTypeVisible(&sess);
 
   // delete expired key by compaction and indexMgr
   sess.setArgs({"config", "set", "noexpire", "no"});
@@ -3136,30 +3044,7 @@ void testExpireKeyWhenCompaction(std::shared_ptr<ServerEntry> svr) {
 
   // test if key exist
   svr->getParams()->noexpire = true;
-  sess.setArgs({"get", "key"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtNull());
-
-  sess.setArgs({"hget", "myhash", "k"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtNull());
-
-  sess.setArgs({"smembers", "myset"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtZeroBulkLen());
-
-  sess.setArgs({"zrange", "myzset", "0", "-1"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtZeroBulkLen());
-
-  sess.setArgs({"lindex", "mylist", "0"});
-  expect = Command::runSessionCmd(&sess);
-  EXPECT_TRUE(expect.ok());
-  EXPECT_EQ(expect.value(), Command::fmtNull());
+  expectExpiredMultiTypeInvisible(&sess);
 }
 
 void testSync(std::shared_ptr<ServerEntry> svr) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
feat(expire): use LOCK_S for read commands to eliminate read-read contention on hot keys #459 

- Add mode parameter to expireKeyIfNeeded: LOCK_X (write path) does
  synchronous delete, LOCK_S (read path) only reports expired without
  deletion, relying on IndexManager's scanExpiredKeysJob for cleanup.

- Refactor delKey into two layers: delKey (acquires lock + reads meta)
  delegates to delKeyInLock (core delete logic assuming LOCK_X held).
  Supports txn=nullptr (self-managed txn) and txn!=nullptr (caller's txn).

- Convert all read commands (GET/MGET/HGET/HLEN/LLEN/SCARD/ZCARD/
  TTL/EXISTS/DUMP/SCAN/PFCOUNT/SORT(readonly)/OBJECT/TBITMAP etc.)
  to use Command::RdLock() for both getDbWithKeyLock and expireKeyIfNeeded.

- Add concurrentRead config parameter (default true) to dynamically
  control lock mode via CONFIG SET, enabling runtime rollback.