### PR TITLE
Fix blob files not reclaimed after deleting all SSTs

### DIFF
--- a/.github/workflows/Tendis-CI.yml
+++ b/.github/workflows/Tendis-CI.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   cpplint-check:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -91,7 +91,7 @@ jobs:
   test-unittest-sh:
     needs: [cpplint-check]
     name: Test-unittest.sh
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
         TEST_DIR: build/bin
     steps:
@@ -116,7 +116,7 @@ jobs:
   test-redistest-sh:
     needs: [cpplint-check]
     name: Test-redistest.sh
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
         TEST_DIR: build/bin
     steps:
@@ -141,7 +141,7 @@ jobs:
   test-restore_test:
     needs: [cpplint-check]
     name: Test-restore_test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
         TEST_DIR: build/bin
     steps:
@@ -156,7 +156,7 @@ jobs:
   test-repl_test:
     needs: [cpplint-check]
     name: Test-repl_test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
         TEST_DIR: build/bin
     steps:
@@ -171,7 +171,7 @@ jobs:
   test-cluster_test-part1:
     needs: [cpplint-check]
     name: Test-cluster_test-part1
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
         TEST_DIR: build/bin
     steps:
@@ -186,7 +186,7 @@ jobs:
   test-cluster_test-part2:
     needs: [cpplint-check]
     name: Test-cluster_test-part2
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
         TEST_DIR: build/bin
     steps:
@@ -201,7 +201,7 @@ jobs:
   test-gotest-normaltest-part1:
     needs: [cpplint-check]
     name: Test-gotest-normaltest-part1
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
         TEST_DIR: build/bin
     steps:
@@ -218,7 +218,7 @@ jobs:
   test-gotest-normaltest-part2:
     needs: [cpplint-check]
     name: Test-gotest-normaltest-part2
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
         TEST_DIR: build/bin
     steps:
@@ -235,7 +235,7 @@ jobs:
   test-gotest-normaltest-part3:
     needs: [cpplint-check]
     name: Test-gotest-normaltest-part3
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
         TEST_DIR: build/bin
     steps:
@@ -252,7 +252,7 @@ jobs:
   test-gotest-versiontest:
     needs: [cpplint-check]
     name: Test-gotest-versiontest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
         GH_TOKEN: ${{ github.token }}
         TEST_DIR: build/bin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
          git am -s ../../patch/0001-add-statistic-for-sst-file-info.patch\;
          git am -s ../../patch/0002-add-latency-statistic-log.patch\;
          git am -s ../../patch/0003-better-control-of-blobldb-space-amp.patch\;
+         git am -s ../../patch/0004-reclaim-blob-files-after-deleting-all-ssts.patch\;
          ")
     execute_process(COMMAND bash "-c" ${patchCommand})
 endif()

--- a/src/thirdparty/patch/0004-reclaim-blob-files-after-deleting-all-ssts.patch
+++ b/src/thirdparty/patch/0004-reclaim-blob-files-after-deleting-all-ssts.patch
@@ -1,0 +1,42 @@
+From a7137cb8b9bdc53abd14943d467f1410078c9abd Mon Sep 17 00:00:00 2001
+From: takenliu <takenliu@tencent.com>
+Date: Thu, 28 May 2026 15:36:00 +0800
+Subject: [PATCH] Fix blob files not reclaimed after deleting all SSTs add
+ tendis_extension.cc in src.mk
+
+---
+ db/version_builder.cc | 6 ++++++
+ src.mk                | 1 +
+ 2 files changed, 7 insertions(+)
+
+diff --git a/db/version_builder.cc b/db/version_builder.cc
+index 210b0de86..9a72307d3 100644
+--- a/db/version_builder.cc
++++ b/db/version_builder.cc
+@@ -1073,6 +1073,12 @@ class VersionBuilder::Rep {
+     const uint64_t oldest_blob_file_with_linked_ssts =
+         GetMinOldestBlobFileNumber();
+ 
++    // If there are no blob files with linked SSTs, meaning that there are no
++    // valid blob files
++    if (oldest_blob_file_with_linked_ssts == kInvalidBlobFileNumber) {
++      return;
++    }
++
+     auto process_base =
+         [vstorage](const std::shared_ptr<BlobFileMetaData>& base_meta) {
+           assert(base_meta);
+diff --git a/src.mk b/src.mk
+index 7d2663b99..5b9890a49 100644
+--- a/src.mk
++++ b/src.mk
+@@ -1,5 +1,6 @@
+ # These are the sources from which librocksdb.a is built:
+ LIB_SOURCES =                                                   \
++  env/tendis_extension.cc                                       \
+   cache/cache.cc                                                \
+   cache/cache_entry_roles.cc                                    \
+   cache/cache_key.cc                                            \
+-- 
+2.41.3
+


### PR DESCRIPTION
开启blob功能的情况下，容易出现新建从节点无法全量同步的问题，备份时容易出现无法生成备份的问题。
https://github.com/Tencent/Tendis/issues/465
主要原因是rocksdb有bug，在columnfamily下面的所有sst文件都被删除的情况下，无法回收blob文件。
see details:
https://github.com/facebook/rocksdb/pull/12235

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Code follows the code style of this project.
- [ ] Change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.