### PR TITLE
fix: skip NOADDR replicas in CLUSTER SLOTS reply

### DIFF
--- a/src/tendisplus/cluster/cluster_manager.cpp
+++ b/src/tendisplus/cluster/cluster_manager.cpp
@@ -1536,11 +1536,17 @@ Status ClusterState::genNodeReplyForClusterSlot(CNodePtr node,
   for (uint16_t i = 0; i < slaveNum; i++) {
     /* This loop is copy/pasted from clusterGenNodeDescription()
      * with modifications for per-slot node aggregation. */
+    CNodePtr slave = slaveList[i];
+    /* Skip replicas whose address is unknown (CLUSTER_NODE_NOADDR).
+     * Exposing them as an empty ip + port 0 makes clients resolve the
+     * node address to ":0" and fail dialing with connection refused. */
+    if (slave->nodeWithoutAddr()) {
+      continue;
+    }
     if (node->nodeFailed()) {
       continue;
     }
     Command::fmtMultiBulkLen(replyDeferred, 3);
-    CNodePtr slave = slaveList[i];
     Command::fmtBulk(replyDeferred, slave->getNodeIp());
     Command::fmtLongLong(replyDeferred, slave->getPort());
     Command::fmtBulk(replyDeferred, slave->getNodeName());


### PR DESCRIPTION
## 问题

当集群中某个 replica 处于 `CLUSTER_NODE_NOADDR` 状态（地址未知，例如 PONG 消息 sender node ID 与本地记录不匹配、节点重启/failover/会话复用导致 node ID 漂移）时，`CLUSTER SLOTS` 会把它输出为 **空 IP + port 0**：

```
5) 1) ""
   2) (integer) 0
   3) "c099eea3..."
```

客户端（如 go-redis）解析该节点地址时 `net.JoinHostPort("", "0")` 会得到 `":0"`，随后去 `dial tcp :0`，必然 `connection refused`，表现为 SLOW_DIAL / 连接失败日志。

## 根因

`genNodeReplyForClusterSlot()` 遍历 master 的 slave 列表时，未过滤 `CLUSTER_NODE_NOADDR` 的节点，把地址未知的 replica 原样暴露给了客户端。

## 修复

在 `genNodeReplyForClusterSlot()` 遍历 slave 时，跳过 `nodeWithoutAddr()`（即 `CLUSTER_NODE_NOADDR`）的节点，与 `clusterGenNodeDescription` 对 NOADDR 的处理保持一致。

## 改动文件

- `src/tendisplus/cluster/cluster_manager.cpp`（+7 -1）
