### PR TITLE
fix: skip NOADDR replicas in CLUSTER SLOTS reply

### DIFF
--- a/src/tendisplus/cluster/cluster_manager.cpp
+++ b/src/tendisplus/cluster/cluster_manager.cpp
@@ -1565,11 +1565,17 @@ Status ClusterState::genNodeReplyForClusterSlot(CNodePtr node,
   for (uint16_t i = 0; i < slaveNum; i++) {
     /* This loop is copy/pasted from clusterGenNodeDescription()
      * with modifications for per-slot node aggregation. */
+    CNodePtr slave = slaveList[i];
+    /* Skip replicas whose address is unknown (CLUSTER_NODE_NOADDR).
+     * Exposing them as an empty ip + port 0 makes clients resolve the
+     * node address to ":0" and fail dialing with connection refused. */
+    if (slave->nodeWithoutAddr()) {
+      continue;
+    }
     if (node->nodeFailed()) {
       continue;
     }
     Command::fmtMultiBulkLen(replyDeferred, 3);
-    CNodePtr slave = slaveList[i];
     Command::fmtBulk(replyDeferred, slave->getNodeIp());
     Command::fmtLongLong(replyDeferred, slave->getPort());
     Command::fmtBulk(replyDeferred, slave->getNodeName());


### PR DESCRIPTION
## 背景

线上 account 服务访问 Tendis 集群时，封装的 go-redis v9 偶发打出这样的慢连接日志：

```
SLOW_DIAL ... addr=:0 ... dial tcp :0: connect: connection refused
```

集群 10.7.2.9 执行CLUSTER SLOTS，发现某个槽位里多出来一个「空 IP + 端口 0」的节点：

```
6) 1) (integer) 13655
   2) (integer) 16383
   3) 1) "10.25.18.200"  6100  (master)
   4) 1) "10.7.140.41"   6200  (replica)
   5) 1) ""                  <- 空 IP
      2) (integer) 0         <- 端口 0
      3) "c099eea3..."       <- 只有 node ID
   6) 1) "10.7.2.9"      6200  (replica)
```

客户端把这个空 IP 和端口 0 用 net.JoinHostPort 一拼，就得到 ":0"，然后去 dial tcp :0 > connection refused。

## 根因

这个「空地址节点」在 Tendis 里对应 CLUSTER_NODE_NOADDR 标志（"we don't know the address of this node"）。

追代码发现，全仓库只有一处会把节点地址清空：

```cpp
// cluster_manager.cpp
} else if (sessNode->getNodeName() != hdr->_sender) {
    // PONG contains mismatching sender ID -> 置为 NOADDR
    sessNode->setFlag(CLUSTER_NODE_NOADDR);
    sessNode->setNodeIp("");
    sessNode->setNodePort(0);
    sessNode->setNodeCport(0);
    ...
}
```

也就是说：当一个节点收到的 PONG 消息里，sender 的 node ID 跟本地记录的 ID 对不上时，Tendis 会把这个节点标记成 NOADDR、清空它的地址，等后续 gossip 再补回来。

什么情况下 ID 会对不上？节点 ID 是启动时 getUUid(20) 随机生成的，所以节点重启 / failover / 大量重连握手时，都容易出现「本地记的还是旧 ID，对端已经换成新 ID」的窗口期，此次正是在 master 故障、连接风暴期间复现的。

问题在于：genNodeReplyForClusterSlot() 遍历 master 的 slave 列表、拼 CLUSTER SLOTS 回复时，没有过滤 NOADDR 节点，把这个「地址未知」的节点原样透给了客户端。

## 修复

在遍历 slave 时跳过 nodeWithoutAddr() 的节点，和 clusterGenNodeDescription 对 NOADDR 的处理保持一致。

## 改动

- src/tendisplus/cluster/cluster_manager.cpp（+7 -1）
