### PR TITLE
Optimization: Read commands no longer require X locks

### DIFF
--- a/.github/workflows/Tendis-CI.yml
+++ b/.github/workflows/Tendis-CI.yml
@@ -1,12 +1,11 @@
 name: Tendis-build-CI
-# Controls when the action will run.
+# Only run on PRs targeting Tencent/Tendis. Do not run on push to persnal forks
 on:
   pull_request:
     branches: [unstable, master, 2.8.tx]
-  push:
-    branches: []
 jobs:
   cpplint-check:
+    if: github.event.pull_request.base.repo.full_name == 'Tencent/Tendis'
     name: Lint
     runs-on: ubuntu-22.04
     steps:
@@ -16,13 +15,14 @@ jobs:
       - name: Prepare Env
         run: |
           python3 -m pip install --upgrade pip
-          pip3 install cpplint
-          export PATH=$PATH:~/.local/bin/
+          pip3 install cpplint==2.0.2
+          pip3 install clang-format==17.0.6
+          export PATH=~/.local/bin:$PATH
           cpplint --version
           clang-format --version
       - name: Lint
         run: |
-          export PATH=$PATH:~/.local/bin/
+          export PATH=~/.local/bin:$PATH
           files=`git diff --name-only HEAD HEAD~1`
           echo "$files" | while read file
           do
@@ -44,7 +44,8 @@ jobs:
           done
       - name: format
         run: |
-          export PATH=$PATH:~/.local/bin/
+          export PATH=~/.local/bin:$PATH
+          clang-format --version
           files=`git diff --name-only HEAD HEAD~1`
           echo "$files" | while read file
           do

--- a/src/tendisplus/commands/command.cpp
+++ b/src/tendisplus/commands/command.cpp
@@ -25,7 +25,7 @@
 namespace tendisplus {
 
 std::mutex Command::_mutex;
-mgl::LockMode Command::_expRdLk = mgl::LockMode::LOCK_X;
+mgl::LockMode Command::_expRdLk = mgl::LockMode::LOCK_S;
 
 std::map<std::string, uint64_t> Command::_unSeenCmds = {};
 
@@ -946,18 +946,18 @@ Status Command::delKey(Session* sess,
   return {ErrorCodes::ERR_INTERNAL, "not reachable"};
 }
 
-// NOTE(takenliu) txn is committed in this function.
-Expected<RecordValue> Command::expireKeyIfNeeded(Session* sess,
-                                                 const std::string& key,
-                                                 RecordType tp,
-                                                 bool hasVersion) {
+// Key lock must already be held (or ignored). If allowDelete is false, an
+// expired key is reported as ERR_EXPIRED without removing it.
+Expected<RecordValue> Command::expireKeyIfNeededOnStore(Session* sess,
+                                                        uint32_t storeId,
+                                                        uint32_t chunkId,
+                                                        PStore kvstore,
+                                                        const std::string& key,
+                                                        RecordType tp,
+                                                        bool hasVersion,
+                                                        bool allowDelete) {
   auto server = sess->getServerEntry();
   INVARIANT(server != nullptr);
-  auto expdb = server->getSegmentMgr()->getDbWithKeyLock(sess, key, RdLock());
-  if (!expdb.ok()) {
-    return expdb.status();
-  }
-  uint32_t storeId = expdb.value().dbId;
 
   // NOTE(wayenchen) change session args to store a del command in session
   LocalSessionGuard sg(server, sess);
@@ -965,14 +965,13 @@ Expected<RecordValue> Command::expireKeyIfNeeded(Session* sess,
     sg.getSession()->setArgs({"del", key});
   }
 
-  RecordKey mk(expdb.value().chunkId, sess->getCtx()->getDbId(), tp, key, "");
-  PStore kvstore = expdb.value().store;
+  RecordKey mk(chunkId, sess->getCtx()->getDbId(), tp, key, "");
 
   // NOTE(takenliu) we need setReplOnly
   sg.getSession()->getCtx()->setReplOnly(kvstore->getMode() ==
                                          KVStore::StoreMode::REPLICATE_ONLY);
 
-  for (uint32_t i = 0; i < RETRY_CNT; ++i) {
+  for (uint32_t i = 0; i < Command::RETRY_CNT; ++i) {
     // NOTE(takenliu) expireKeyIfNeeded don't use txn from params,
     //   because it need rewrite codes too much.
     //   so, we need new txn and commit txn in this function,
@@ -1013,9 +1012,11 @@ Expected<RecordValue> Command::expireKeyIfNeeded(Session* sess,
       }
       ++sess->getServerEntry()->getServerStat().keyspaceHits;
       return eValue.value();
-    } else if (txn->isReplOnly()) {
+    } else if (txn->isReplOnly() || !allowDelete) {
       // NOTE(vinchen): if replOnly, it can't delete record, but return
       // ErrorCodes::ERR_EXPIRED
+      // Holding LOCK_S cannot upgrade to X; leave deletion to writers /
+      // IndexManager.
       return {ErrorCodes::ERR_EXPIRED, ""};
     }
     auto cnt = rcd_util::getSubKeyCount(mk, eValue.value());
@@ -1049,6 +1050,73 @@ Expected<RecordValue> Command::expireKeyIfNeeded(Session* sess,
   // should never reach here
   INVARIANT_D(0);
   return {ErrorCodes::ERR_INTERNAL, "not reachable"};
+}
+
+// NOTE(takenliu) txn is committed in this function.
+Expected<RecordValue> Command::expireKeyIfNeeded(Session* sess,
+                                                 const std::string& key,
+                                                 RecordType tp,
+                                                 bool hasVersion) {
+  auto server = sess->getServerEntry();
+  INVARIANT(server != nullptr);
+  auto held = sess->getCtx()->getKeyLockMode(key);
+
+  // Already locked by the caller: never upgrade. S/IS => check only; X =>
+  // delete if expired.
+  if (held != mgl::LockMode::LOCK_NONE) {
+    auto expdb = server->getSegmentMgr()->getDbHasLocked(sess, key);
+    if (!expdb.ok()) {
+      return expdb.status();
+    }
+    bool allowDelete = (held == mgl::LockMode::LOCK_X);
+    return expireKeyIfNeededOnStore(sess,
+                                    expdb.value().dbId,
+                                    expdb.value().chunkId,
+                                    expdb.value().store,
+                                    key,
+                                    tp,
+                                    hasVersion,
+                                    allowDelete);
+  }
+
+  // No key lock yet: probe with S so unexpired reads can run concurrently.
+  {
+    auto expdb = server->getSegmentMgr()->getDbWithKeyLock(
+      sess, key, mgl::LockMode::LOCK_S);
+    if (!expdb.ok()) {
+      return expdb.status();
+    }
+    auto result = expireKeyIfNeededOnStore(sess,
+                                           expdb.value().dbId,
+                                           expdb.value().chunkId,
+                                           expdb.value().store,
+                                           key,
+                                           tp,
+                                           hasVersion,
+                                           false);
+    if (result.ok() || result.status().code() != ErrorCodes::ERR_EXPIRED) {
+      return result;
+    }
+    if (expdb.value().store->getMode() == KVStore::StoreMode::REPLICATE_ONLY ||
+        server->getParams()->noexpire) {
+      return result;
+    }
+  }
+
+  // Expired under S. Drop S (scope above), take X, re-check, then delete.
+  auto expdb =
+    server->getSegmentMgr()->getDbWithKeyLock(sess, key, mgl::LockMode::LOCK_X);
+  if (!expdb.ok()) {
+    return expdb.status();
+  }
+  return expireKeyIfNeededOnStore(sess,
+                                  expdb.value().dbId,
+                                  expdb.value().chunkId,
+                                  expdb.value().store,
+                                  key,
+                                  tp,
+                                  hasVersion,
+                                  true);
 }
 
 std::string Command::fmtErr(const std::string& s) {

--- a/src/tendisplus/commands/command.h
+++ b/src/tendisplus/commands/command.h
@@ -65,6 +65,8 @@ class Command {
   bool isMultiKey() const;
   bool isWriteable() const;
   bool isAdmin() const;
+  // Shared lock for read commands. Expired keys are not deleted while S is
+  // held; writers / IndexManager take X and delete.
   static mgl::LockMode RdLock();
   static void changeCommand(const std::string& renameCmdList, std::string mode);
   int getFlags() const;
@@ -150,6 +152,15 @@ class Command {
   static mgl::LockMode _expRdLk;
 
  private:
+  static Expected<RecordValue> expireKeyIfNeededOnStore(Session* sess,
+                                                        uint32_t storeId,
+                                                        uint32_t chunkId,
+                                                        PStore kvstore,
+                                                        const std::string& key,
+                                                        RecordType tp,
+                                                        bool hasVersion,
+                                                        bool allowDelete);
+
   static Status delKeyPessimisticInLock(Session* sess,
                                         uint32_t storeId,
                                         const RecordKey& rk,

--- a/src/tendisplus/commands/hash.cpp
+++ b/src/tendisplus/commands/hash.cpp
@@ -6,6 +6,7 @@
 #include <cctype>
 #include <clocale>
 #include <list>
+#include <map>
 #include <memory>
 #include <string>
 #include <utility>
@@ -963,7 +964,7 @@ Status hmcas(Session* sess,
 
   auto server = sess->getServerEntry();
   auto expdb =
-    server->getSegmentMgr()->getDbWithKeyLock(sess, key, Command::RdLock());
+    server->getSegmentMgr()->getDbWithKeyLock(sess, key, mgl::LockMode::LOCK_X);
   if (!expdb.ok()) {
     return expdb.status();
   }
@@ -1001,7 +1002,7 @@ Status hmcas(Session* sess,
 
   if (cmp) {
     // kv should exist for comparison
-    if (eValue.ok() && (int64_t)vsn != cas && cas != -1) {
+    if (eValue.ok() && static_cast<int64_t>(vsn) != cas && cas != -1) {
       return {ErrorCodes::ERR_CAS, ""};
     }
   }

--- a/src/tendisplus/commands/tbitmap.cpp
+++ b/src/tendisplus/commands/tbitmap.cpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <queue>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -552,7 +553,7 @@ class TBitCountCommand : public Command {
     }
 
     // whole bitmap except the first element
-    if ((uint64_t)start < meta.fragmentLen() && end >= len - 1) {
+    if (static_cast<uint64_t>(start) < meta.fragmentLen() && end >= len - 1) {
       INVARIANT_D(start >= 1);
       auto cnt = redis_port::popCount(meta.firstFragment(), 0, start - 1);
       return Command::fmtLongLong(meta.count() - cnt);
@@ -562,7 +563,7 @@ class TBitCountCommand : public Command {
     auto firstFrag = start / meta.fragmentLen();
     auto offset = start;
 
-    if ((uint64_t)start < meta.fragmentLen()) {
+    if (static_cast<uint64_t>(start) < meta.fragmentLen()) {
       bitcount += redis_port::popCount(meta.firstFragment(), start, end);
 
       offset = meta.fragmentLen();
@@ -599,11 +600,11 @@ class TBitCountCommand : public Command {
       auto efragId = fragmentIdDecode(subRk.getSecondaryKey());
       RET_IF_ERR_EXPECTED(efragId);
       auto fragId = efragId.value();
-      if (fragId * meta.fragmentLen() > (uint64_t)end) {
+      if (fragId * meta.fragmentLen() > static_cast<uint64_t>(end)) {
         break;
       }
 
-      if ((uint64_t)offset < fragId * meta.fragmentLen()) {
+      if (static_cast<uint64_t>(offset) < fragId * meta.fragmentLen()) {
         offset = fragId * meta.fragmentLen();
       }
 
@@ -690,7 +691,7 @@ class TBitPosCommand : public Command {
     auto firstFrag = start / meta.fragmentLen();
     auto offset = start;
 
-    if ((uint64_t)start < meta.fragmentLen()) {
+    if (static_cast<uint64_t>(start) < meta.fragmentLen()) {
       auto pos = redis_port::bitPos(meta.firstFragment(), start, end, bit);
       if (pos != -1) {
         /* If we are looking for clear bits, and the user specified an exact
@@ -740,11 +741,11 @@ class TBitPosCommand : public Command {
       auto efragId = fragmentIdDecode(subRk.getSecondaryKey());
       RET_IF_ERR_EXPECTED(efragId);
       auto fragId = efragId.value();
-      if (fragId * meta.fragmentLen() > (uint64_t)end) {
+      if (fragId * meta.fragmentLen() > static_cast<uint64_t>(end)) {
         break;
       }
 
-      if ((uint64_t)offset < fragId * meta.fragmentLen()) {
+      if (static_cast<uint64_t>(offset) < fragId * meta.fragmentLen()) {
         offset = fragId * meta.fragmentLen();
       }
 
@@ -896,8 +897,8 @@ class TBitFieldCommand : public Command {
     conv.u = ev.value();
     ret = conv.i;
 
-    if (ret & ((uint64_t)1 << (bits - 1)))
-      ret |= ((uint64_t)-1) << bits;
+    if (ret & (static_cast<uint64_t>(1) << (bits - 1)))
+      ret |= (static_cast<uint64_t>(-1)) << bits;
 
     return ret;
   }
@@ -907,11 +908,12 @@ class TBitFieldCommand : public Command {
                                     uint64_t bits,
                                     BFOverFlowType owtype,
                                     uint64_t* newVal) {
-    uint64_t max = (bits == 64) ? UINT64_MAX : (((uint64_t)1 << bits) - 1);
+    uint64_t max =
+      (bits == 64) ? UINT64_MAX : ((static_cast<uint64_t>(1) << bits) - 1);
     int64_t maxincr = max - value;
     int64_t minincr = -value;
     auto handleWrap = [&]() {
-      uint64_t mask = ((uint64_t)-1) << bits;
+      uint64_t mask = (static_cast<uint64_t>(-1)) << bits;
       uint64_t res = value + incr;
       res &= ~mask;
       *newVal = res;
@@ -941,15 +943,16 @@ class TBitFieldCommand : public Command {
                                   uint64_t bits,
                                   BFOverFlowType owtype,
                                   int64_t* newVal) {
-    int64_t max = (bits == 64) ? INT64_MAX : (((int64_t)1 << (bits - 1)) - 1);
+    int64_t max =
+      (bits == 64) ? INT64_MAX : ((static_cast<int64_t>(1) << (bits - 1)) - 1);
     int64_t min = (-max) - 1;
 
     int64_t maxincr = max - value;
     int64_t minincr = min - value;
 
     auto handleWrap = [&]() {
-      uint64_t mask = ((uint64_t)-1) << bits;
-      uint64_t msb = (uint64_t)1 << (bits - 1);
+      uint64_t mask = (static_cast<uint64_t>(-1)) << bits;
+      uint64_t msb = static_cast<uint64_t>(1) << (bits - 1);
       uint64_t a = value, b = incr, c;
       c = a + b;
 
@@ -1006,7 +1009,8 @@ class TBitFieldCommand : public Command {
     std::string buf = ebuf.value();
 
     for (size_t i = 0; i < bits; i++) {
-      uint64_t bitval = (value & ((uint64_t)1 << (bits - 1 - i))) != 0;
+      uint64_t bitval =
+        (value & (static_cast<uint64_t>(1) << (bits - 1 - i))) != 0;
       uint64_t byte = offset >> 3;
       uint64_t bit = 7 - (offset & 0x7);
       uint8_t byteval = static_cast<uint8_t>(buf[byte]);
@@ -1167,8 +1171,6 @@ class TBitFieldCommand : public Command {
     auto txn = eptxn.value();
     auto chunkId = edb.value().chunkId;
 
-    bool metaExists = true;
-
     auto emetaRv =
       Command::expireKeyIfNeeded(sess, key, RecordType::RT_TBITMAP_META);
     uint64_t fragmentLen =
@@ -1176,7 +1178,8 @@ class TBitFieldCommand : public Command {
     TBitMapMetaValue meta(fragmentLen);
     if (emetaRv.status().code() == ErrorCodes::ERR_EXPIRED ||
         emetaRv.status().code() == ErrorCodes::ERR_NOTFOUND) {
-      metaExists = false;
+      // GET on a missing/expired key: keep the default empty meta, and don't
+      // persist it. Only LOCK_S is held here.
     } else if (emetaRv.status().code() == ErrorCodes::ERR_WRONG_TYPE) {
       auto it = commandMap().find("bitfield");
       if (it == commandMap().end()) {
@@ -1332,7 +1335,7 @@ class TBitFieldCommand : public Command {
       }
     }
 
-    if (!metaExists || !readonly) {
+    if (!readonly) {
       RecordKey metaRk(
         chunkId, pctx->getDbId(), RecordType::RT_TBITMAP_META, key, "");
       Status s = kvstore->setKV(metaRk,

--- a/src/tendisplus/network/session_ctx.cpp
+++ b/src/tendisplus/network/session_ctx.cpp
@@ -7,6 +7,8 @@
 #include <algorithm>
 #include <list>
 #include <string>
+#include <tuple>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -296,6 +298,15 @@ bool SessionCtx::isLockedByMe(const std::string& key, mgl::LockMode mode) {
     return true;
   }
   return false;
+}
+
+mgl::LockMode SessionCtx::getKeyLockMode(const std::string& key) const {
+  std::lock_guard<std::mutex> lk(_mutex);
+  auto it = _keylockmap.find(key);
+  if (it == _keylockmap.end()) {
+    return mgl::LockMode::LOCK_NONE;
+  }
+  return it->second;
 }
 
 bool SessionCtx::verifyVersion(uint64_t keyVersion) {

--- a/src/tendisplus/network/session_ctx.h
+++ b/src/tendisplus/network/session_ctx.h
@@ -110,6 +110,7 @@ class SessionCtx {
   void unsetKeylock(const std::string& key);
 
   bool isLockedByMe(const std::string& key, mgl::LockMode mode);
+  mgl::LockMode getKeyLockMode(const std::string& key) const;
 
   uint32_t getIsMonitor() const;
   void setIsMonitor(bool in);

--- a/src/tendisplus/utils/test_util.cpp
+++ b/src/tendisplus/utils/test_util.cpp
@@ -3034,8 +3034,14 @@ void testExpireKeyWhenCompaction(std::shared_ptr<ServerEntry> svr) {
   asio::ip::tcp::socket socket(ioContext), socket1(ioContext);
   NetSession sess(svr, std::move(socket), 1, false, nullptr, nullptr);
 
-  sess.setArgs({"config", "set", "noexpire", "yes"});
+  // Isolate from leftover keys of testExpireKeyWhenGet (S-lock reads do not
+  // physically delete expired composite types).
+  sess.setArgs({"del", "key", "myhash", "myset", "myzset", "mylist"});
   auto expect = Command::runSessionCmd(&sess);
+  EXPECT_TRUE(expect.ok());
+
+  sess.setArgs({"config", "set", "noexpire", "yes"});
+  expect = Command::runSessionCmd(&sess);
   EXPECT_TRUE(expect.ok());
   EXPECT_EQ(expect.value(), Command::fmtOK());
 


### PR DESCRIPTION
…ving the read concurrency of hot keys.

<!--- Provide a general summary of your changes in the Title above -->
#459
#473 

之前读/写命令都需要调用expireKeyIfNeeded()函数，函数内在key过期的情况下需要删除key，所以一直上的是写锁。
优化：
  expireKeyIfNeeded()函数不再上写锁，这样读命令就不再因为写锁而互斥，从而提高并发。

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Code follows the code style of this project.
- [ ] Change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.